### PR TITLE
Implement NoData skipping and other `apply` params

### DIFF
--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -138,7 +138,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         X_image: ImageType,
         *,
         skip_nodata: bool = True,
-        nodata_vals: NoDataType = None,
+        nodata_input: NoDataType = None,
+        nodata_output: float | int = np.nan,
         **predict_kwargs,
     ) -> ImageType:
         """
@@ -158,11 +159,15 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             If True, NoData and NaN values will be skipped during prediction. This
             speeds up processing of partially masked images, but may be incompatible if
             estimators expect a consistent number of input samples.
-        nodata_vals : float or sequence of floats, optional
+        nodata_input : float or sequence of floats, optional
             NoData values other than NaN to mask in the output image. A single value
             will be broadcast to all bands while sequences of values will be assigned
             band-wise. If None, values will be inferred if possible based on image
             metadata.
+        nodata_output : float or int, default np.nan
+            NoData pixels in the input features will be replaced with this value in the
+            output targets. If the value does not fit the array dtype returned by the
+            estimator, an error will be raised.
         **predict_kwargs
             Additional arguments passed to the estimator's predict method.
 
@@ -172,7 +177,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             The predicted values.
         """
         output_dim_name = "variable"
-        image = Image.from_image(X_image, nodata_vals=nodata_vals)
+        image = Image.from_image(X_image, nodata_input=nodata_input)
 
         self._check_feature_names(image.band_names)
 
@@ -188,6 +193,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             output_sizes={output_dim_name: self._wrapped_meta.n_targets},
             output_coords={output_dim_name: list(self._wrapped_meta.target_names)},
             skip_nodata=skip_nodata,
+            nodata_output=nodata_output,
+            prevent_empty_array=True,
             **predict_kwargs,
         )
 
@@ -201,7 +208,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         n_neighbors: int | None = None,
         return_distance: Literal[False] = False,
         skip_nodata: bool = False,
-        nodata_vals: NoDataType = None,
+        nodata_input: NoDataType = None,
+        nodata_output: float | int = np.nan,
         **kneighbors_kwargs,
     ) -> ImageType: ...
 
@@ -215,7 +223,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         n_neighbors: int | None = None,
         return_distance: Literal[True] = True,
         skip_nodata: bool = False,
-        nodata_vals: NoDataType = None,
+        nodata_input: NoDataType = None,
+        nodata_output: float | int = np.nan,
         **kneighbors_kwargs,
     ) -> tuple[ImageType, ImageType]: ...
 
@@ -228,7 +237,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         n_neighbors: int | None = None,
         return_distance: bool = True,
         skip_nodata: bool = False,
-        nodata_vals: NoDataType = None,
+        nodata_input: NoDataType = None,
+        nodata_output: float | int = np.nan,
         **kneighbors_kwargs,
     ) -> ImageType | tuple[ImageType, ImageType]:
         """
@@ -256,11 +266,15 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             If True, NoData and NaN values will be skipped during prediction. This
             speeds up processing of partially masked images, but may be incompatible if
             estimators expect a consistent number of input samples.
-        nodata_vals : float or sequence of floats, optional
+        nodata_input : float or sequence of floats, optional
             NoData values other than NaN to mask in the output image. A single value
             will be broadcast to all bands while sequences of values will be assigned
             band-wise. If None, values will be inferred if possible based on image
             metadata.
+        nodata_output : float or int, default np.nan
+            NoData pixels in the input features will be replaced with this value in the
+            output targets. If the value does not fit the array dtype returned by the
+            estimator, an error will be raised.
         **kneighbors_kwargs
             Additional arguments passed to the estimator's kneighbors method.
 
@@ -272,7 +286,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         neigh_ind : Numpy or Xarray image with 3 dimensions (y, x, neighbor)
             Indices of the nearest points in the population matrix.
         """
-        image = Image.from_image(X_image, nodata_vals=nodata_vals)
+        image = Image.from_image(X_image, nodata_input=nodata_input)
         k = n_neighbors or cast(int, getattr(self._wrapped, "n_neighbors", 5))
 
         self._check_feature_names(image.band_names)
@@ -286,6 +300,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             n_neighbors=k,
             return_distance=return_distance,
             skip_nodata=skip_nodata,
+            nodata_output=nodata_output,
+            prevent_empty_array=True,
             **kneighbors_kwargs,
         )
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -140,6 +140,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         skip_nodata: bool = True,
         nodata_input: NoDataType = None,
         nodata_output: float | int = np.nan,
+        ensure_min_samples: int = 1,
         **predict_kwargs,
     ) -> ImageType:
         """
@@ -168,6 +169,11 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             NoData pixels in the input features will be replaced with this value in the
             output targets. If the value does not fit the array dtype returned by the
             estimator, an error will be raised.
+        ensure_min_samples : int, default 1
+            The minimum number of samples to include even if the array is fully masked
+            and `skip_nodata=True`. The minimum supported number of samples depends on
+            the estimator used. No effect if the array contains enough valid pixels or
+            if `skip_nodata=False`.
         **predict_kwargs
             Additional arguments passed to the estimator's predict method.
 
@@ -194,7 +200,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             output_coords={output_dim_name: list(self._wrapped_meta.target_names)},
             skip_nodata=skip_nodata,
             nodata_output=nodata_output,
-            prevent_empty_array=True,
+            ensure_min_samples=ensure_min_samples,
             **predict_kwargs,
         )
 
@@ -210,6 +216,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         skip_nodata: bool = False,
         nodata_input: NoDataType = None,
         nodata_output: float | int = np.nan,
+        ensure_min_samples: int = 1,
         **kneighbors_kwargs,
     ) -> ImageType: ...
 
@@ -225,6 +232,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         skip_nodata: bool = False,
         nodata_input: NoDataType = None,
         nodata_output: float | int = np.nan,
+        ensure_min_samples: int = 1,
         **kneighbors_kwargs,
     ) -> tuple[ImageType, ImageType]: ...
 
@@ -239,6 +247,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         skip_nodata: bool = False,
         nodata_input: NoDataType = None,
         nodata_output: float | int = np.nan,
+        ensure_min_samples: int = 1,
         **kneighbors_kwargs,
     ) -> ImageType | tuple[ImageType, ImageType]:
         """
@@ -275,6 +284,11 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             NoData pixels in the input features will be replaced with this value in the
             output targets. If the value does not fit the array dtype returned by the
             estimator, an error will be raised.
+        ensure_min_samples : int, default 1
+            The minimum number of samples to include even if the array is fully masked
+            and `skip_nodata=True`. The minimum supported number of samples depends on
+            the estimator used. No effect if the array contains enough valid pixels or
+            if `skip_nodata=False`.
         **kneighbors_kwargs
             Additional arguments passed to the estimator's kneighbors method.
 
@@ -301,7 +315,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             return_distance=return_distance,
             skip_nodata=skip_nodata,
             nodata_output=nodata_output,
-            prevent_empty_array=True,
+            ensure_min_samples=ensure_min_samples,
             **kneighbors_kwargs,
         )
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -134,7 +134,12 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
     @check_wrapper_implements
     @image_or_fallback
     def predict(
-        self, X_image: ImageType, *, nodata_vals: NoDataType = None, **predict_kwargs
+        self,
+        X_image: ImageType,
+        *,
+        nodata_vals: NoDataType = None,
+        nodata_handling: Literal["fill", "skip"] = "fill",
+        **predict_kwargs,
     ) -> ImageType:
         """
         Predict target(s) for X_image.
@@ -177,6 +182,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             output_dtypes=[output_dtype],
             output_sizes={output_dim_name: self._wrapped_meta.n_targets},
             output_coords={output_dim_name: list(self._wrapped_meta.target_names)},
+            nodata_handling=nodata_handling,
             **predict_kwargs,
         )
 
@@ -215,6 +221,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         n_neighbors: int | None = None,
         return_distance: bool = True,
         nodata_vals: NoDataType = None,
+        nodata_handling: Literal["fill", "skip"] = "fill",
         **kneighbors_kwargs,
     ) -> ImageType | tuple[ImageType, ImageType]:
         """
@@ -266,6 +273,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             output_coords={"k": list(range(1, k + 1))},
             n_neighbors=k,
             return_distance=return_distance,
+            nodata_handling=nodata_handling,
             **kneighbors_kwargs,
         )
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -171,10 +171,11 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             output targets. If the value does not fit the array dtype returned by the
             estimator, an error will be raised.
         ensure_min_samples : int, default 1
-            The minimum number of samples to include even if the array is fully masked
-            and `skip_nodata=True`. The minimum supported number of samples depends on
-            the estimator used. No effect if the array contains enough valid pixels or
-            if `skip_nodata=False`.
+            The minimum number of samples that should be passed to `predict`. If the
+            array is fully masked and `skip_nodata=True`, dummy values (0) will be
+            inserted to ensure this number of samples. The minimum supported number of
+            samples depends on the estimator used. No effect if the array contains
+            enough valid pixels or if `skip_nodata=False`.
         allow_cast : bool, default=False
             If True and the estimator output dtype is incompatible with the chosen
             `nodata_output` value, the output will be cast to the correct dtype.
@@ -294,10 +295,11 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             output targets. If the value does not fit the array dtype returned by the
             estimator, an error will be raised.
         ensure_min_samples : int, default 1
-            The minimum number of samples to include even if the array is fully masked
-            and `skip_nodata=True`. The minimum supported number of samples depends on
-            the estimator used. No effect if the array contains enough valid pixels or
-            if `skip_nodata=False`.
+            The minimum number of samples that should be passed to `kneighbors`. If the
+            array is fully masked and `skip_nodata=True`, dummy values (0) will be
+            inserted to ensure this number of samples. The minimum supported number of
+            samples depends on the estimator used. No effect if the array contains
+            enough valid pixels or if `skip_nodata=False`.
         allow_cast : bool, default=False
             If True and the estimator output dtype is incompatible with the chosen
             `nodata_output` value, the output will be cast to the correct dtype.

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -228,7 +228,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         return_distance: Literal[False] = False,
         skip_nodata: bool = False,
         nodata_input: NoDataType = None,
-        nodata_output: float | int = np.nan,
+        nodata_output: float | int = -2147483648,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
@@ -246,7 +246,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         return_distance: Literal[True] = True,
         skip_nodata: bool = False,
         nodata_input: NoDataType = None,
-        nodata_output: float | int = np.nan,
+        nodata_output: float | int = -2147483648,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
@@ -263,7 +263,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         return_distance: bool = True,
         skip_nodata: bool = False,
         nodata_input: NoDataType = None,
-        nodata_output: float | int = np.nan,
+        nodata_output: float | int = -2147483648,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
@@ -299,10 +299,11 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             will be broadcast to all bands while sequences of values will be assigned
             band-wise. If None, values will be inferred if possible based on image
             metadata.
-        nodata_output : float or int, default np.nan
+        nodata_output : float or int, default -2147483648
             NoData pixels in the input features will be replaced with this value in the
-            output targets. If the value does not fit the array dtype returned by the
-            estimator, an error will be raised unless `allow_cast` is True.
+            output neighbor IDs and distances. The default value is the minimum value
+            If the value does not fit the array dtype returned by the estimator, an
+            error will be raised unless `allow_cast` is True.
         ensure_min_samples : int, default 1
             The minimum number of samples that should be passed to `kneighbors`. If the
             array is fully masked and `skip_nodata=True`, dummy values (0) will be

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -170,7 +170,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_output : float or int, default np.nan
             NoData pixels in the input features will be replaced with this value in the
             output targets. If the value does not fit the array dtype returned by the
-            estimator, an error will be raised.
+            estimator, an error will be raised unless `allow_cast` is True.
         ensure_min_samples : int, default 1
             The minimum number of samples that should be passed to `predict`. If the
             array is fully masked and `skip_nodata=True`, dummy values (0) will be
@@ -302,7 +302,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_output : float or int, default np.nan
             NoData pixels in the input features will be replaced with this value in the
             output targets. If the value does not fit the array dtype returned by the
-            estimator, an error will be raised.
+            estimator, an error will be raised unless `allow_cast` is True.
         ensure_min_samples : int, default 1
             The minimum number of samples that should be passed to `kneighbors`. If the
             array is fully masked and `skip_nodata=True`, dummy values (0) will be

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -214,6 +214,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             ensure_min_samples=ensure_min_samples,
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
+            nan_fill=0.0,
             **predict_kwargs,
         )
 
@@ -347,6 +348,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             ensure_min_samples=ensure_min_samples,
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
+            nan_fill=0.0,
             **kneighbors_kwargs,
         )
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -141,6 +141,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_input: NoDataType = None,
         nodata_output: float | int = np.nan,
         ensure_min_samples: int = 1,
+        allow_cast: bool = False,
         **predict_kwargs,
     ) -> ImageType:
         """
@@ -174,6 +175,10 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             and `skip_nodata=True`. The minimum supported number of samples depends on
             the estimator used. No effect if the array contains enough valid pixels or
             if `skip_nodata=False`.
+        allow_cast : bool, default=False
+            If True and the estimator output dtype is incompatible with the chosen
+            `nodata_output` value, the output will be cast to the correct dtype.
+            Otherwise, an error will be raised.
         **predict_kwargs
             Additional arguments passed to the estimator's predict method.
 
@@ -201,6 +206,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             skip_nodata=skip_nodata,
             nodata_output=nodata_output,
             ensure_min_samples=ensure_min_samples,
+            allow_cast=allow_cast,
             **predict_kwargs,
         )
 
@@ -217,6 +223,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_input: NoDataType = None,
         nodata_output: float | int = np.nan,
         ensure_min_samples: int = 1,
+        allow_cast: bool = False,
         **kneighbors_kwargs,
     ) -> ImageType: ...
 
@@ -233,6 +240,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_input: NoDataType = None,
         nodata_output: float | int = np.nan,
         ensure_min_samples: int = 1,
+        allow_cast: bool = False,
         **kneighbors_kwargs,
     ) -> tuple[ImageType, ImageType]: ...
 
@@ -248,6 +256,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_input: NoDataType = None,
         nodata_output: float | int = np.nan,
         ensure_min_samples: int = 1,
+        allow_cast: bool = False,
         **kneighbors_kwargs,
     ) -> ImageType | tuple[ImageType, ImageType]:
         """
@@ -289,6 +298,10 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             and `skip_nodata=True`. The minimum supported number of samples depends on
             the estimator used. No effect if the array contains enough valid pixels or
             if `skip_nodata=False`.
+        allow_cast : bool, default=False
+            If True and the estimator output dtype is incompatible with the chosen
+            `nodata_output` value, the output will be cast to the correct dtype.
+            Otherwise, an error will be raised.
         **kneighbors_kwargs
             Additional arguments passed to the estimator's kneighbors method.
 
@@ -316,6 +329,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             skip_nodata=skip_nodata,
             nodata_output=nodata_output,
             ensure_min_samples=ensure_min_samples,
+            allow_cast=allow_cast,
             **kneighbors_kwargs,
         )
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -142,6 +142,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_output: float | int = np.nan,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
+        check_output_for_nodata: bool = True,
         **predict_kwargs,
     ) -> ImageType:
         """
@@ -180,6 +181,10 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             If True and the estimator output dtype is incompatible with the chosen
             `nodata_output` value, the output will be cast to the correct dtype.
             Otherwise, an error will be raised.
+        check_output_for_nodata : bool, default True
+            If True and `nodata_output` is not np.nan, a warning will be raised if the
+            selected `nodata_output` value is returned by the estimator, as this may
+            indicate a valid pixel being masked.
         **predict_kwargs
             Additional arguments passed to the estimator's predict method.
 
@@ -208,6 +213,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             nodata_output=nodata_output,
             ensure_min_samples=ensure_min_samples,
             allow_cast=allow_cast,
+            check_output_for_nodata=check_output_for_nodata,
             **predict_kwargs,
         )
 
@@ -225,6 +231,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_output: float | int = np.nan,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
+        check_output_for_nodata: bool = True,
         **kneighbors_kwargs,
     ) -> ImageType: ...
 
@@ -242,6 +249,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_output: float | int = np.nan,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
+        check_output_for_nodata: bool = True,
         **kneighbors_kwargs,
     ) -> tuple[ImageType, ImageType]: ...
 
@@ -258,6 +266,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         nodata_output: float | int = np.nan,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
+        check_output_for_nodata: bool = True,
         **kneighbors_kwargs,
     ) -> ImageType | tuple[ImageType, ImageType]:
         """
@@ -304,6 +313,10 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             If True and the estimator output dtype is incompatible with the chosen
             `nodata_output` value, the output will be cast to the correct dtype.
             Otherwise, an error will be raised.
+        check_output_for_nodata : bool, default True
+            If True and `nodata_output` is not np.nan, a warning will be raised if the
+            selected `nodata_output` value is returned by the estimator, as this may
+            indicate a valid pixel being masked.
         **kneighbors_kwargs
             Additional arguments passed to the estimator's kneighbors method.
 
@@ -332,6 +345,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             nodata_output=nodata_output,
             ensure_min_samples=ensure_min_samples,
             allow_cast=allow_cast,
+            check_output_for_nodata=check_output_for_nodata,
             **kneighbors_kwargs,
         )
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -137,8 +137,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         self,
         X_image: ImageType,
         *,
+        skip_nodata: bool = True,
         nodata_vals: NoDataType = None,
-        nodata_handling: Literal["fill", "skip"] = "fill",
         **predict_kwargs,
     ) -> ImageType:
         """
@@ -154,10 +154,15 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         X_image : Numpy or Xarray image with 3 dimensions (y, x, band)
             The input image. Features in the band dimension should correspond with the
             features used to fit the estimator.
+        skip_nodata : bool, default=False
+            If True, NoData and NaN values will be skipped during prediction. This
+            speeds up processing of partially masked images, but may be incompatible if
+            estimators expect a consistent number of input samples.
         nodata_vals : float or sequence of floats, optional
-            NoData values to mask in the output image. A single value will be broadcast
-            to all bands while sequences of values will be assigned band-wise. If None,
-            values will be inferred if possible based on image metadata.
+            NoData values other than NaN to mask in the output image. A single value
+            will be broadcast to all bands while sequences of values will be assigned
+            band-wise. If None, values will be inferred if possible based on image
+            metadata.
         **predict_kwargs
             Additional arguments passed to the estimator's predict method.
 
@@ -182,7 +187,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             output_dtypes=[output_dtype],
             output_sizes={output_dim_name: self._wrapped_meta.n_targets},
             output_coords={output_dim_name: list(self._wrapped_meta.target_names)},
-            nodata_handling=nodata_handling,
+            skip_nodata=skip_nodata,
             **predict_kwargs,
         )
 
@@ -195,6 +200,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         *,
         n_neighbors: int | None = None,
         return_distance: Literal[False] = False,
+        skip_nodata: bool = False,
         nodata_vals: NoDataType = None,
         **kneighbors_kwargs,
     ) -> ImageType: ...
@@ -208,6 +214,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         *,
         n_neighbors: int | None = None,
         return_distance: Literal[True] = True,
+        skip_nodata: bool = False,
         nodata_vals: NoDataType = None,
         **kneighbors_kwargs,
     ) -> tuple[ImageType, ImageType]: ...
@@ -220,8 +227,8 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         *,
         n_neighbors: int | None = None,
         return_distance: bool = True,
+        skip_nodata: bool = False,
         nodata_vals: NoDataType = None,
-        nodata_handling: Literal["fill", "skip"] = "fill",
         **kneighbors_kwargs,
     ) -> ImageType | tuple[ImageType, ImageType]:
         """
@@ -245,10 +252,15 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         return_distance : bool, default=True
             If True, return distances to the neighbors of each sample. If False, return
             indices only.
+        skip_nodata : bool, default=False
+            If True, NoData and NaN values will be skipped during prediction. This
+            speeds up processing of partially masked images, but may be incompatible if
+            estimators expect a consistent number of input samples.
         nodata_vals : float or sequence of floats, optional
-            NoData values to mask in the output image. A single value will be broadcast
-            to all bands while sequences of values will be assigned band-wise. If None,
-            values will be inferred if possible based on image metadata.
+            NoData values other than NaN to mask in the output image. A single value
+            will be broadcast to all bands while sequences of values will be assigned
+            band-wise. If None, values will be inferred if possible based on image
+            metadata.
         **kneighbors_kwargs
             Additional arguments passed to the estimator's kneighbors method.
 
@@ -273,7 +285,7 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
             output_coords={"k": list(range(1, k + 1))},
             n_neighbors=k,
             return_distance=return_distance,
-            nodata_handling=nodata_handling,
+            skip_nodata=skip_nodata,
             **kneighbors_kwargs,
         )
 

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sized
-from typing import Any, Callable, Generic
+from typing import Any, Generic
 
 import numpy as np
 import xarray as xr
 from numpy.typing import NDArray
-from typing_extensions import Concatenate
 
-from .types import ImageType, NoDataType, P
+from .types import ArrayUfunc, ImageType, NoDataType
 from .ufunc import UfuncArrayProcessor
 
 
@@ -61,7 +60,7 @@ class Image(Generic[ImageType], ABC):
 
     def apply_ufunc_across_bands(
         self,
-        func: Callable[Concatenate[NDArray, P], NDArray],
+        func: ArrayUfunc,
         *,
         output_dims: list[list[str]],
         output_dtypes: list[np.dtype] | None = None,

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -132,6 +132,7 @@ class _ImageChunk:
                 flat_array=flat_array,
                 prevent_empty_array=prevent_empty_array,
                 nan_fill=nan_fill,
+                mask_nodata=mask_nodata,
                 **kwargs,
             )
             # NoData is now pre-masked
@@ -167,8 +168,9 @@ class _ImageChunk:
 
         def insert_result(result: NDArray):
             """Insert the array result for valid pixels into the full-shaped array."""
-            # We can pre-fill with NaN to skip filling later
+            nonlocal nan_fill
             if mask_nodata:
+                # We can pre-fill with NaN to skip filling later
                 nan_fill = np.nan
 
             full_result = np.full((flat_array.shape[0], result.shape[-1]), nan_fill)

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -62,7 +62,7 @@ class _ImageChunk:
         # TODO: Avoid repeating this check
         if not np.can_cast(type(nodata_output), flat_image.dtype):
             msg = (
-                f"The selected `nodata_output` value {nodata_output} cannot be cast to "
+                f"The selected `nodata_output` value {nodata_output} does not fit in "
                 f"the array dtype {flat_image.dtype}."
             )
             raise ValueError(msg)
@@ -140,8 +140,6 @@ class _ImageChunk:
         else:
             flat_array = np.where(np.isnan(self.flat_array), nan_fill, self.flat_array)
 
-        mask_nodata = self._num_masked > 0
-
         # Only skip NoData if there's something to skip
         if skip_nodata and self._num_masked > 0:
             flat_result = self._masked_apply(
@@ -155,6 +153,7 @@ class _ImageChunk:
             mask_nodata = False
         else:
             flat_result = func(flat_array, **kwargs)
+            mask_nodata = self._num_masked > 0
 
         return self._postprocess(
             flat_result, mask_nodata=mask_nodata, nodata_output=nodata_output
@@ -185,8 +184,8 @@ class _ImageChunk:
             # TODO: Avoid repeating this check here
             if not np.can_cast(type(nodata_output), result.dtype):
                 msg = (
-                    f"The selected `nodata_output` value {nodata_output} cannot be "
-                    f"cast to the array dtype {result.dtype}."
+                    f"The selected `nodata_output` value {nodata_output} does not fit "
+                    f"in the array dtype {result.dtype}."
                 )
                 raise ValueError(msg)
 

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sized
-from typing import Any, Callable, Generic, cast
+from typing import Any, Callable, Generic
 
 import numpy as np
 import xarray as xr
@@ -10,207 +10,7 @@ from numpy.typing import NDArray
 from typing_extensions import Concatenate
 
 from .types import ImageType, NoDataType, P
-
-
-class _ImageChunk:
-    """
-    A chunk of an NDArray in shape (y, x, band).
-
-    Note that this dimension order is different from the (band, y, x) order used by
-    rasterio, rioxarray, and elsewhere in sklearn-raster. This is because `_ImageChunk`
-    is called via `xr.apply_ufunc` which automatically swaps the core dimension to the
-    last axis, resulting in arrays of (y, x, band).
-    """
-
-    band_dim = -1
-
-    def __init__(self, array: NDArray, nodata_input: list[float] | None = None):
-        self.array = array
-        self.nodata_input = nodata_input
-        self.flat_array = array.reshape(-1, array.shape[self.band_dim])
-
-        # We can take some shortcuts if the input array type can't contain NaNs
-        self._input_supports_nan = np.issubdtype(array.dtype, np.floating)
-        self.nodata_mask = self._get_flat_nodata_mask()
-
-        num_pixels = self.flat_array.shape[0]
-        self._num_masked = 0 if self.nodata_mask is None else self.nodata_mask.sum()
-        self._num_unmasked = num_pixels - self._num_masked
-
-    def _get_flat_nodata_mask(self) -> NDArray | None:
-        # Skip allocating a mask if the image is not float and NoData wasn't given
-        if not self._input_supports_nan and self.nodata_input is None:
-            return None
-
-        mask = np.zeros(self.flat_array.shape, dtype=bool)
-
-        # If it's floating point, always mask NaNs
-        if self._input_supports_nan:
-            mask |= np.isnan(self.flat_array)
-
-        # If NoData was specified, mask those values
-        if self.nodata_input is not None:
-            mask |= self.flat_array == self.nodata_input
-
-        # Return a mask where any band contains NoData
-        return mask.max(axis=self.band_dim)
-
-    def _validate_nodata_output(
-        self, output: NDArray, nodata_output: float | int
-    ) -> None:
-        """Check that a given output array can support the NoData value."""
-        if not np.can_cast(type(nodata_output), output.dtype):
-            msg = (
-                f"The selected `nodata_output` value {nodata_output} does not fit in "
-                f"the array dtype {output.dtype}."
-            )
-            raise ValueError(msg)
-
-    def _mask_nodata(self, flat_image: NDArray, nodata_output: float | int) -> NDArray:
-        """
-        Replace NoData values in the input array with `output_nodata`.
-        """
-        self._validate_nodata_output(flat_image, nodata_output)
-        flat_image[self.nodata_mask] = nodata_output
-        return flat_image
-
-    # TODO: Try to refactor out the need for the mask_nodata parameter.
-    def _postprocess(
-        self,
-        result: NDArray | tuple[NDArray, ...],
-        nodata_output: float | int,
-        mask_nodata: bool = True,
-    ) -> NDArray | tuple[NDArray, ...]:
-        """Postprocess results by unflattening to (y, x, band) and masking NoData."""
-        if isinstance(result, tuple):
-            return tuple(
-                self._postprocess(
-                    array, mask_nodata=mask_nodata, nodata_output=nodata_output
-                )
-                for array in result
-            )
-
-        output_shape = [*self.array.shape[:2], -1]
-        if mask_nodata:
-            result = self._mask_nodata(result, nodata_output=nodata_output)
-
-        return result.reshape(output_shape)
-
-    def apply(
-        self,
-        func,
-        *,
-        skip_nodata: bool = True,
-        nodata_output: float | int = np.nan,
-        nan_fill: float | int | None = None,
-        ensure_min_samples: int = 1,
-        **kwargs,
-    ) -> NDArray | tuple[NDArray]:
-        """
-        Apply a function to the flattened chunk.
-
-        The function should accept and return one or more NDArrays in shape
-        (pixels, bands). The output will be reshaped back to the original chunk shape.
-
-        Parameters
-        ----------
-        func : callable
-            A function to apply to the flattened array. The function should accept one
-            array of shape (pixels, bands) and return one or more arrays of the same
-            shape.
-        skip_nodata : bool, default True
-            If True, NoData and NaN values will be removed before passing the array to
-            `func`. This can speed up processing of partially masked arrays, but may be
-            incompatible with functions that expect a consistent number of samples.
-        nodata_output : float or int, default np.nan
-            NoData pixels in the input will be replaced with this value in the output.
-            If the value does not fit the array dtype returned by `func`, an error will
-            be raised.
-        nan_fill : float or int, optional
-            If `skip_nodata=False`, any NaNs in the input array will be filled with this
-            value prior to calling `func` to avoid errors from functions that do not
-            support NaN inputs. If None, NaNs will not be filled.
-        ensure_min_samples : int, default 1
-            The minimum number of samples passed to `func` even if the array is fully
-            masked and `skip_nodata=True`. This is necessary for functions that require
-            non-empty array inputs, like some scikit-learn `predict` methods. No effect
-            if the array contains enough valid pixels or if `skip_nodata=False`.
-        **kwargs : dict
-            Additional keyword arguments passed to `func`.
-        """
-        # No need to fill NaNs if they're skipped anyways or unsupported
-        if skip_nodata is True or self._input_supports_nan is False or nan_fill is None:
-            flat_array = self.flat_array
-        else:
-            flat_array = np.where(np.isnan(self.flat_array), nan_fill, self.flat_array)
-
-        # Only skip NoData if there's something to skip
-        if skip_nodata and self._num_masked > 0:
-            flat_result = self._masked_apply(
-                func,
-                flat_array=flat_array,
-                ensure_min_samples=ensure_min_samples,
-                nodata_output=nodata_output,
-                **kwargs,
-            )
-            # NoData is now pre-masked
-            mask_nodata = False
-        else:
-            flat_result = func(flat_array, **kwargs)
-            mask_nodata = self._num_masked > 0
-
-        return self._postprocess(
-            flat_result, mask_nodata=mask_nodata, nodata_output=nodata_output
-        )
-
-    def _masked_apply(
-        self,
-        func,
-        *,
-        flat_array: NDArray,
-        nodata_output: float | int,
-        ensure_min_samples: int,
-        **kwargs,
-    ) -> NDArray | tuple[NDArray, ...]:
-        """
-        Apply a function to all non-NoData values in a flat array.
-        """
-        if inserted_dummy_values := self._num_unmasked < ensure_min_samples:
-            if ensure_min_samples > flat_array.shape[0]:
-                raise ValueError(
-                    f"Cannot ensure {ensure_min_samples} samples with only "
-                    f"{flat_array.shape[0]} total pixels in the image chunk."
-                )
-
-            cast(NDArray, self.nodata_mask)[:ensure_min_samples] = False
-            flat_array[:ensure_min_samples] = 0
-
-        def insert_result(result: NDArray):
-            """Insert the array result for valid pixels into the full-shaped array."""
-            self._validate_nodata_output(result, nodata_output)
-
-            # Build an output array pre-masked with the fill value and cast to the
-            # output dtype. The shape will be (n, b) where n is the number of pixels
-            # in the flat array and b is the number of bands in the func result.
-            full_result = np.full(
-                (flat_array.shape[0], result.shape[-1]),
-                nodata_output,
-                dtype=result.dtype,
-            )
-            full_result[~cast(NDArray, self.nodata_mask)] = result
-
-            # Re-mask any pixels that were filled to ensure minimum samples
-            if inserted_dummy_values:
-                cast(NDArray, self.nodata_mask)[:ensure_min_samples] = True
-                full_result[:ensure_min_samples] = nodata_output
-
-            return full_result
-
-        func_result = func(flat_array[~cast(NDArray, self.nodata_mask)], **kwargs)
-        if isinstance(func_result, tuple):
-            return tuple(insert_result(result) for result in func_result)
-
-        return insert_result(func_result)
+from .ufunc import UfuncArrayProcessor
 
 
 class Image(Generic[ImageType], ABC):
@@ -283,7 +83,8 @@ class Image(Generic[ImageType], ABC):
             }
 
         def ufunc(x):
-            return _ImageChunk(x, nodata_input=self.nodata_input).apply(
+            x = self._preprocess_ufunc_input(x)
+            return UfuncArrayProcessor(x, nodata_input=self.nodata_input).apply(
                 func,
                 skip_nodata=skip_nodata,
                 nodata_output=nodata_output,
@@ -294,7 +95,7 @@ class Image(Generic[ImageType], ABC):
 
         result = xr.apply_ufunc(
             ufunc,
-            self._preprocess_ufunc_input(self.image),
+            self.image,
             dask="parallelized",
             input_core_dims=[[self.band_dim_name]],
             exclude_dims=set((self.band_dim_name,)),

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -72,6 +72,7 @@ class Image(Generic[ImageType], ABC):
         nan_fill: float = 0.0,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
+        check_output_for_nodata: bool = True,
         **ufunc_kwargs,
     ) -> ImageType | tuple[ImageType]:
         """Apply a universal function to all bands of the image."""
@@ -90,6 +91,7 @@ class Image(Generic[ImageType], ABC):
                 nan_fill=nan_fill,
                 ensure_min_samples=ensure_min_samples,
                 allow_cast=allow_cast,
+                check_output_for_nodata=check_output_for_nodata,
                 **ufunc_kwargs,
             )
 

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -71,6 +71,7 @@ class Image(Generic[ImageType], ABC):
         nodata_output: float | int = np.nan,
         nan_fill: float = 0.0,
         ensure_min_samples: int = 1,
+        allow_cast: bool = False,
         **ufunc_kwargs,
     ) -> ImageType | tuple[ImageType]:
         """Apply a universal function to all bands of the image."""
@@ -88,6 +89,7 @@ class Image(Generic[ImageType], ABC):
                 nodata_output=nodata_output,
                 nan_fill=nan_fill,
                 ensure_min_samples=ensure_min_samples,
+                allow_cast=allow_cast,
                 **ufunc_kwargs,
             )
 

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -69,7 +69,7 @@ class Image(Generic[ImageType], ABC):
         output_coords: dict[str, list[str | int]] | None = None,
         skip_nodata: bool = True,
         nodata_output: float | int = np.nan,
-        nan_fill: float = 0.0,
+        nan_fill: float | int | None = None,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -472,8 +472,5 @@ class DatasetImage(DataArrayImage):
         for var in ds.data_vars:
             if not np.isnan(nodata_output):
                 ds[var].attrs["_FillValue"] = nodata_output
-            else:
-                # Remove the _FillValue copied from the input array
-                ds[var].attrs.pop("_FillValue", None)
 
         return ds

--- a/src/sklearn_raster/types.py
+++ b/src/sklearn_raster/types.py
@@ -22,4 +22,4 @@ RT = TypeVar("RT")
 MaybeTuple = Union[T, tuple[T, ...]]
 
 # A function that takes an NDArray and any parameters and returns one or more NDArrays
-ArrayUfunc = Callable[Concatenate[NDArray, P], NDArray | tuple[NDArray, ...]]
+ArrayUfunc = Callable[Concatenate[NDArray, P], Union[NDArray, tuple[NDArray, ...]]]

--- a/src/sklearn_raster/types.py
+++ b/src/sklearn_raster/types.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Callable, Concatenate, Union
+from typing import Callable, Union
 
 import xarray as xr
 from numpy.typing import NDArray
 from sklearn.base import BaseEstimator
-from typing_extensions import Any, ParamSpec, TypeVar
+from typing_extensions import Any, Concatenate, ParamSpec, TypeVar
 
 DaskBackedType = TypeVar("DaskBackedType", xr.DataArray, xr.Dataset)
 ImageType = TypeVar("ImageType", NDArray, xr.DataArray, xr.Dataset)

--- a/src/sklearn_raster/types.py
+++ b/src/sklearn_raster/types.py
@@ -13,8 +13,13 @@ ImageType = TypeVar("ImageType", NDArray, xr.DataArray, xr.Dataset)
 EstimatorType = TypeVar("EstimatorType", bound=BaseEstimator)
 AnyType = TypeVar("AnyType", bound=Any)
 NoDataType = Union[float, Sequence[float], None]
+
+Self = TypeVar("Self")
+T = TypeVar("T")
 P = ParamSpec("P")
 RT = TypeVar("RT")
+
+MaybeTuple = Union[T, tuple[T, ...]]
 
 # A function that takes an NDArray and any parameters and returns one or more NDArrays
 ArrayUfunc = Callable[Concatenate[NDArray, P], NDArray | tuple[NDArray, ...]]

--- a/src/sklearn_raster/types.py
+++ b/src/sklearn_raster/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Union
+from typing import Callable, Concatenate, Union
 
 import xarray as xr
 from numpy.typing import NDArray
@@ -15,3 +15,6 @@ AnyType = TypeVar("AnyType", bound=Any)
 NoDataType = Union[float, Sequence[float], None]
 P = ParamSpec("P")
 RT = TypeVar("RT")
+
+# A function that takes an NDArray and any parameters and returns one or more NDArrays
+ArrayUfunc = Callable[Concatenate[NDArray, P], NDArray | tuple[NDArray, ...]]

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+class UfuncArrayProcessor:
+    """
+    A processor for applying ufuncs to arrays.
+
+    The processor takes Numpy arrays (images or image chunks) and:
+
+    1. Flattens 2D spatial dimensions to a 1D sample dimension.
+    2. Fills NaN pixels in the input array.
+    3. Passes samples to the ufunc.
+    4. Masks NoData values in the ufunc output.
+
+    Note that this dimension order is different from the (band, y, x) order used by
+    rasterio, rioxarray, and elsewhere in sklearn-raster. This is because `_ImageChunk`
+    is called via `xr.apply_ufunc` which automatically swaps the core dimension to the
+    last axis, resulting in arrays of (y, x, band).
+    """
+
+    band_dim = -1
+
+    def __init__(self, array: NDArray, *, nodata_input: list[float] | None = None):
+        self.array = array
+        self.nodata_input = nodata_input
+        self.flat_array = array.reshape(-1, array.shape[self.band_dim])
+
+        # We can take some shortcuts if the input array type can't contain NaNs
+        self._input_supports_nan = np.issubdtype(array.dtype, np.floating)
+        self.nodata_mask = self._get_flat_nodata_mask()
+
+        num_pixels = self.flat_array.shape[0]
+        self._num_masked = 0 if self.nodata_mask is None else self.nodata_mask.sum()
+        self._num_unmasked = num_pixels - self._num_masked
+
+    def _get_flat_nodata_mask(self) -> NDArray | None:
+        # Skip allocating a mask if the image is not float and NoData wasn't given
+        if not self._input_supports_nan and self.nodata_input is None:
+            return None
+
+        mask = np.zeros(self.flat_array.shape, dtype=bool)
+
+        # If it's floating point, always mask NaNs
+        if self._input_supports_nan:
+            mask |= np.isnan(self.flat_array)
+
+        # If NoData was specified, mask those values
+        if self.nodata_input is not None:
+            mask |= self.flat_array == self.nodata_input
+
+        # Return a mask where any band contains NoData
+        return mask.max(axis=self.band_dim)
+
+    def _fill_flat_nans(self, nan_fill: float | None) -> NDArray:
+        """Fill the flat input array with NaNs filled."""
+        if nan_fill is not None and self._input_supports_nan:
+            return np.where(np.isnan(self.flat_array), nan_fill, self.flat_array)
+
+        return self.flat_array
+
+    def apply(
+        self,
+        func,
+        *,
+        skip_nodata: bool = True,
+        nodata_output: float | int = np.nan,
+        nan_fill: float | int | None = None,
+        ensure_min_samples: int = 1,
+        **kwargs,
+    ) -> NDArray | tuple[NDArray]:
+        """
+        Apply a function to the flattened chunk.
+
+        The function should accept and return one or more NDArrays in shape
+        (pixels, bands). The output will be reshaped back to the original chunk shape.
+
+        Parameters
+        ----------
+        func : callable
+            A function to apply to the flattened array. The function should accept one
+            array of shape (pixels, bands) and return one or more arrays of the same
+            shape.
+        skip_nodata : bool, default True
+            If True, NoData and NaN values will be removed before passing the array to
+            `func`. This can speed up processing of partially masked arrays, but may be
+            incompatible with functions that expect a consistent number of samples.
+        nodata_output : float or int, default np.nan
+            NoData pixels in the input will be replaced with this value in the output.
+            If the value does not fit the array dtype returned by `func`, an error will
+            be raised.
+        nan_fill : float or int, optional
+            If `skip_nodata=False`, any NaNs in the input array will be filled with this
+            value prior to calling `func` to avoid errors from functions that do not
+            support NaN inputs. If None, NaNs will not be filled.
+        ensure_min_samples : int, default 1
+            The minimum number of samples passed to `func` even if the array is fully
+            masked and `skip_nodata=True`. This is necessary for functions that require
+            non-empty array inputs, like some scikit-learn `predict` methods. No effect
+            if the array contains enough valid pixels or if `skip_nodata=False`.
+        **kwargs : dict
+            Additional keyword arguments passed to `func`.
+        """
+        # Fill NaNs in the input array if they're not being skipped
+        flat_array = self.flat_array if skip_nodata else self._fill_flat_nans(nan_fill)
+
+        # Only skip NoData if there's something to skip
+        if skip_nodata and self._num_masked > 0:
+            flat_result = self._masked_apply(
+                func,
+                flat_array=flat_array,
+                ensure_min_samples=ensure_min_samples,
+                nodata_output=nodata_output,
+                **kwargs,
+            )
+            # NoData is now pre-masked
+            mask_nodata = False
+        else:
+            flat_result = func(flat_array, **kwargs)
+            mask_nodata = self._num_masked > 0
+
+        return self._postprocess(
+            flat_result, mask_nodata=mask_nodata, nodata_output=nodata_output
+        )
+
+    def _masked_apply(
+        self,
+        func,
+        *,
+        flat_array: NDArray,
+        nodata_output: float | int,
+        ensure_min_samples: int,
+        **kwargs,
+    ) -> NDArray | tuple[NDArray, ...]:
+        """
+        Apply a function to all non-NoData values in a flat array.
+        """
+        if inserted_dummy_values := self._num_unmasked < ensure_min_samples:
+            if ensure_min_samples > flat_array.shape[0]:
+                raise ValueError(
+                    f"Cannot ensure {ensure_min_samples} samples with only "
+                    f"{flat_array.shape[0]} total pixels in the image chunk."
+                )
+
+            cast(NDArray, self.nodata_mask)[:ensure_min_samples] = False
+            flat_array[:ensure_min_samples] = 0
+
+        def insert_result(result: NDArray):
+            """Insert the array result for valid pixels into the full-shaped array."""
+            self._validate_nodata_output(result, nodata_output)
+
+            # Build an output array pre-masked with the fill value and cast to the
+            # output dtype. The shape will be (n, b) where n is the number of pixels
+            # in the flat array and b is the number of bands in the func result.
+            full_result = np.full(
+                (flat_array.shape[0], result.shape[-1]),
+                nodata_output,
+                dtype=result.dtype,
+            )
+            full_result[~cast(NDArray, self.nodata_mask)] = result
+
+            # Re-mask any pixels that were filled to ensure minimum samples
+            if inserted_dummy_values:
+                cast(NDArray, self.nodata_mask)[:ensure_min_samples] = True
+                full_result[:ensure_min_samples] = nodata_output
+
+            return full_result
+
+        func_result = func(flat_array[~cast(NDArray, self.nodata_mask)], **kwargs)
+        if isinstance(func_result, tuple):
+            return tuple(insert_result(result) for result in func_result)
+
+        return insert_result(func_result)
+
+    def _mask_nodata(self, flat_image: NDArray, nodata_output: float | int) -> NDArray:
+        """
+        Replace NoData values in the input array with `output_nodata`.
+        """
+        self._validate_nodata_output(flat_image, nodata_output)
+        flat_image[self.nodata_mask] = nodata_output
+        return flat_image
+
+    def _validate_nodata_output(
+        self, output: NDArray, nodata_output: float | int
+    ) -> None:
+        """Check that a given output array can support the NoData value."""
+        if not np.can_cast(type(nodata_output), output.dtype):
+            msg = (
+                f"The selected `nodata_output` value {nodata_output} does not fit in "
+                f"the array dtype {output.dtype}."
+            )
+            raise ValueError(msg)
+
+    # TODO: Try to refactor out the need for the mask_nodata parameter.
+    def _postprocess(
+        self,
+        result: NDArray | tuple[NDArray, ...],
+        nodata_output: float | int,
+        mask_nodata: bool = True,
+    ) -> NDArray | tuple[NDArray, ...]:
+        """Postprocess results by unflattening to (y, x, band) and masking NoData."""
+        if isinstance(result, tuple):
+            return tuple(
+                self._postprocess(
+                    array, mask_nodata=mask_nodata, nodata_output=nodata_output
+                )
+                for array in result
+            )
+
+        output_shape = [*self.array.shape[:2], -1]
+        if mask_nodata:
+            result = self._mask_nodata(result, nodata_output=nodata_output)
+
+        return result.reshape(output_shape)

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -221,10 +221,17 @@ class UfuncArrayProcessor:
 
         Cast (if allowed) or raise if not.
         """
-        if not np.can_cast(type(nodata_output), output.dtype):
+        # Use the minimum dtype for integers. Otherwise, just use the value's type to
+        # avoid casting to low-precision float16.
+        nodata_output_type = (
+            np.min_scalar_type(nodata_output)
+            if np.issubdtype(type(nodata_output), np.integer)
+            else type(nodata_output)
+        )
+
+        if not np.can_cast(nodata_output_type, output.dtype):
             if allow_cast:
-                # TODO: Make sure this is the right way to cast
-                output = output.astype(type(nodata_output))
+                output = output.astype(nodata_output_type)
             else:
                 msg = (
                     f"The selected `nodata_output` value {nodata_output} does not fit "

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -116,7 +116,7 @@ class UfuncArrayProcessor:
             `nodata_output` value, the output will be cast to the correct dtype.
             Otherwise, an error will be raised unless `allow_cast` is True.
         check_output_for_nodata : bool, default True
-            If True and `nodata_output` is not np.nan, a warning will be raised if the
+            If True and `nodata_output` is not NaN, a warning will be raised if the
             selected `nodata_output` value is returned by `func`, as this may indicate
             a valid pixel being masked.
         **kwargs : dict

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -170,9 +170,7 @@ class UfuncArrayProcessor:
         check_output_for_nodata: bool,
         **kwargs,
     ) -> NDArray | tuple[NDArray, ...]:
-        """
-        Apply a function to all non-NoData values in a flat array.
-        """
+        """Apply a function to all non-NoData values in a flat array."""
         # The NoData mask is guaranteed to exist since this method is only called when
         # there are masked pixels, so we can safely cast it for type checking.
         nodata_mask = cast(NDArray, self.nodata_mask)
@@ -232,9 +230,7 @@ class UfuncArrayProcessor:
         allow_cast: bool,
         check_output_for_nodata: bool,
     ) -> NDArray:
-        """
-        Replace NoData values in the input array with `output_nodata`.
-        """
+        """Replace NoData values in the input array with `output_nodata`."""
         flat_image = self._validate_nodata_output(
             flat_image,
             nodata_output,

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -102,10 +102,12 @@ class UfuncArrayProcessor:
             value prior to calling `func` to avoid errors from functions that do not
             support NaN inputs. If None, NaNs will not be filled.
         ensure_min_samples : int, default 1
-            The minimum number of samples passed to `func` even if the array is fully
-            masked and `skip_nodata=True`. This is necessary for functions that require
-            non-empty array inputs, like some scikit-learn `predict` methods. No effect
-            if the array contains enough valid pixels or if `skip_nodata=False`.
+            The minimum number of samples that should be passed to `func`. If the array
+            is fully masked and `skip_nodata=True`, dummy values (`nan_fill` or 0) will
+            be inserted to ensure this number of samples. This is necessary for
+            functions that require non-empty array inputs, like some scikit-learn
+            `predict` methods. No effect if the array contains enough valid pixels or if
+            `skip_nodata=False`.
         allow_cast : bool, default False
             If True and the `func` output dtype is incompatible with the chosen
             `nodata_output` value, the output will be cast to the correct dtype.
@@ -124,6 +126,7 @@ class UfuncArrayProcessor:
                 ensure_min_samples=ensure_min_samples,
                 nodata_output=nodata_output,
                 allow_cast=allow_cast,
+                nan_fill=nan_fill,
                 **kwargs,
             )
             # NoData is now pre-masked
@@ -153,6 +156,7 @@ class UfuncArrayProcessor:
         nodata_output: float | int,
         ensure_min_samples: int,
         allow_cast: bool,
+        nan_fill: float | int | None,
         **kwargs,
     ) -> NDArray | tuple[NDArray, ...]:
         """
@@ -166,7 +170,7 @@ class UfuncArrayProcessor:
                 )
 
             cast(NDArray, self.nodata_mask)[:ensure_min_samples] = False
-            flat_array[:ensure_min_samples] = 0
+            flat_array[:ensure_min_samples] = nan_fill if nan_fill is not None else 0
 
         @map_function_over_tuples
         def populate_missing_pixels(result: NDArray) -> NDArray:

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -14,7 +14,8 @@ class UfuncArrayProcessor:
     """
     A processor for applying ufuncs to arrays.
 
-    The processor takes Numpy arrays (images or image chunks) and:
+    The processor takes Numpy arrays (images or image chunks) in the shape (y, x, band)
+    and:
 
     1. Flattens 2D spatial dimensions to a 1D sample dimension.
     2. Fills NaN pixels in the input array.
@@ -22,9 +23,9 @@ class UfuncArrayProcessor:
     4. Masks NoData values in the ufunc output.
 
     Note that this dimension order is different from the (band, y, x) order used by
-    rasterio, rioxarray, and elsewhere in sklearn-raster. This is because `_ImageChunk`
-    is called via `xr.apply_ufunc` which automatically swaps the core dimension to the
-    last axis, resulting in arrays of (y, x, band).
+    rasterio, rioxarray, and elsewhere in sklearn-raster. This is because
+    `UfuncArrayProcessor` is called via `xr.apply_ufunc` which automatically swaps the
+    core dimension to the last axis, resulting in arrays of (y, x, band).
     """
 
     band_dim = -1

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -113,7 +113,7 @@ class UfuncArrayProcessor:
         allow_cast : bool, default False
             If True and the `func` output dtype is incompatible with the chosen
             `nodata_output` value, the output will be cast to the correct dtype.
-            Otherwise, an error will be raised.
+            Otherwise, an error will be raised unless `allow_cast` is True.
         check_output_for_nodata : bool, default True
             If True and `nodata_output` is not np.nan, a warning will be raised if the
             selected `nodata_output` value is returned by `func`, as this may indicate

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -61,13 +61,6 @@ class UfuncArrayProcessor:
         # Return a mask where any band contains NoData
         return mask.max(axis=self.band_dim)
 
-    def _fill_flat_nans(self, nan_fill: float | None) -> NDArray:
-        """Fill the flat input array with NaNs filled."""
-        if nan_fill is not None and self._input_supports_nan:
-            return np.where(np.isnan(self.flat_array), nan_fill, self.flat_array)
-
-        return self.flat_array
-
     def apply(
         self,
         func: ArrayUfunc,
@@ -157,6 +150,13 @@ class UfuncArrayProcessor:
             return result.reshape(output_shape)
 
         return _unflatten_and_mask(flat_result)
+
+    def _fill_flat_nans(self, nan_fill: float | None) -> NDArray:
+        """Fill the flat input array with NaNs filled."""
+        if nan_fill is not None and self._input_supports_nan:
+            return np.where(np.isnan(self.flat_array), nan_fill, self.flat_array)
+
+        return self.flat_array
 
     def _skip_nodata_apply(
         self,

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -5,6 +5,8 @@ from typing import cast
 import numpy as np
 from numpy.typing import NDArray
 
+from .types import ArrayUfunc
+
 
 class UfuncArrayProcessor:
     """
@@ -65,7 +67,7 @@ class UfuncArrayProcessor:
 
     def apply(
         self,
-        func,
+        func: ArrayUfunc,
         *,
         skip_nodata: bool = True,
         nodata_output: float | int = np.nan,
@@ -129,7 +131,7 @@ class UfuncArrayProcessor:
 
     def _masked_apply(
         self,
-        func,
+        func: ArrayUfunc,
         *,
         flat_array: NDArray,
         nodata_output: float | int,
@@ -170,6 +172,7 @@ class UfuncArrayProcessor:
 
             return full_result
 
+        # Apply the func only to valid pixels
         func_result = func(flat_array[~cast(NDArray, self.nodata_mask)], **kwargs)
         if isinstance(func_result, tuple):
             return tuple(insert_result(result) for result in func_result)

--- a/src/sklearn_raster/utils/wrapper.py
+++ b/src/sklearn_raster/utils/wrapper.py
@@ -1,12 +1,9 @@
 from functools import wraps
 from typing import Callable, Generic
 
-from typing_extensions import Concatenate, ParamSpec, TypeVar
+from typing_extensions import Concatenate, TypeVar
 
-from ..types import AnyType
-
-RT = TypeVar("RT")
-P = ParamSpec("P")
+from ..types import RT, AnyType, MaybeTuple, P, Self, T
 
 
 class AttrWrapper(Generic[AnyType]):
@@ -41,5 +38,44 @@ def check_wrapper_implements(
             raise NotImplementedError(msg)
 
         return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def map_function_over_tuples(
+    func: Callable[Concatenate[T, P], T],
+) -> Callable[Concatenate[MaybeTuple[T], P], MaybeTuple[T]]:
+    """
+    Decorate a function that accepts and returns type T to also accept and return tuples
+    of type T by mapping the function over each element.
+
+    The function will be mapped over the first positional argument.
+    """
+
+    def wrapper(arg: MaybeTuple[T], *args: P.args, **kwargs: P.kwargs) -> MaybeTuple[T]:
+        if isinstance(arg, tuple):
+            return tuple(func(arg, *args, **kwargs) for arg in arg)
+        return func(arg, *args, **kwargs)
+
+    return wrapper
+
+
+def map_method_over_tuples(
+    func: Callable[Concatenate[Self, T, P], T],
+) -> Callable[Concatenate[Self, MaybeTuple[T], P], MaybeTuple[T]]:
+    """
+    Decorate a method that accepts and returns type T to also accept and return tuples
+    of type T by mapping the method over each element.
+
+    The method will be mapped over the second positional argument (i.e. excluding
+    `self`).
+    """
+
+    def wrapper(
+        self: Self, arg: MaybeTuple[T], *args: P.args, **kwargs: P.kwargs
+    ) -> MaybeTuple[T]:
+        if isinstance(arg, tuple):
+            return tuple(func(self, arg, *args, **kwargs) for arg in arg)
+        return func(self, arg, *args, **kwargs)
 
     return wrapper

--- a/tests/image_utils.py
+++ b/tests/image_utils.py
@@ -10,16 +10,13 @@ from numpy.typing import NDArray
 
 from sklearn_raster.types import ImageType
 
-# Parametrize over all supported image types
-parametrize_image_types = pytest.mark.parametrize(
-    "image_type",
-    [
-        np.ndarray,
-        xr.DataArray,
-        xr.Dataset,
-    ],
-    ids=lambda t: t.__name__,
-)
+
+def parametrize_image_types(
+    label="image_type",
+    image_types=(np.ndarray, xr.DataArray, xr.Dataset),
+):
+    """Parametrize over multiple image types."""
+    return pytest.mark.parametrize(label, image_types, ids=lambda t: t.__name__)
 
 
 class ModelData(Generic[ImageType]):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -114,7 +114,7 @@ def test_nodata_output_set(
     a = np.array([[[nodata_input, 1, np.nan]]])
     expected_output = np.array([[[nodata_output, 1, nodata_output]]])
 
-    image = Image.from_image(wrap_image(a, type=image_type), nodata_input=0)
+    image = Image.from_image(wrap_image(a, type=image_type), nodata_input=nodata_input)
     result = image.apply_ufunc_across_bands(
         lambda x: x,
         nodata_output=nodata_output,

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,5 +1,7 @@
 """Test the image module."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -16,16 +18,18 @@ from .image_utils import (
 
 
 @parametrize_image_types
-def test_input_array_not_mutated(image_type: type[ImageType]):
+@pytest.mark.parametrize("skip_nodata", [True, False])
+def test_input_array_not_mutated(image_type: type[ImageType], skip_nodata: bool):
     """Ensure that applying a ufunc to an image doesn't mutate the original array."""
     array = np.array([[[0, 1]], [[1, np.nan]]])
     original_array = array.copy()
 
     img = wrap_image(array, type=image_type)
 
-    image = Image.from_image(img, nodata_vals=0)
+    image = Image.from_image(img, nodata_input=0)
     image.apply_ufunc_across_bands(
         lambda x: x * 2.0,
+        skip_nodata=skip_nodata,
         output_dims=[["variable"]],
         output_sizes={"variable": array.shape[0]},
         output_dtypes=[array.dtype],
@@ -35,72 +39,106 @@ def test_input_array_not_mutated(image_type: type[ImageType]):
 
 
 @parametrize_image_types
-@pytest.mark.parametrize("nan_fill", [None, 42.0])
-def test_nans_filled(nan_fill, image_type: type[ImageType]):
-    """Test that NaNs in the image are filled or not."""
-    a = np.random.rand(3, 8, 8)
-    a[1][0][0] = np.nan
-    a[2][4][3] = np.nan
+@pytest.mark.parametrize("skip_nodata", [True, False])
+@pytest.mark.parametrize("val_dtype", [(-1, np.uint8), (np.nan, np.int16)])
+def test_nodata_output_with_unsupported_dtype(
+    val_dtype: tuple[int | float, np.dtype],
+    image_type: type[ImageType],
+    skip_nodata: bool,
+):
+    """Test that an unsupported nodata_output value raises an error."""
+    # Make sure there's a value to mask in the input array
+    a = np.array([[[np.nan]]])
+    img = wrap_image(a, type=image_type)
+    image = Image.from_image(img, nodata_input=0)
 
-    if nan_fill is not None:
-        expected_output = np.where(np.isnan(a), nan_fill, a)
-    else:
-        expected_output = a.copy()
+    output_nodata, output_dtype = val_dtype
+    with pytest.raises(ValueError, match="does not fit in the array dtype"):
+        # Unwrap to force computation for lazy arrays
+        unwrap_image(
+            image.apply_ufunc_across_bands(
+                lambda x: np.ones_like(x).astype(output_dtype),
+                nodata_output=output_nodata,
+                skip_nodata=skip_nodata,
+                output_dims=[["variable"]],
+                output_sizes={"variable": a.shape[0]},
+                output_dtypes=[a.dtype],
+            )
+        )
 
-    image = Image.from_image(wrap_image(a, type=image_type))
 
-    output = image.apply_ufunc_across_bands(
-        func=lambda x: x,
-        nan_fill=nan_fill,
-        # Masking NoData would broadcast NaNs across the band dimension since a missing
-        # value in any band is considered missing in all bands of the output, so skip
-        # that step.
-        mask_nodata=False,
+@pytest.mark.parametrize("nodata_output", [np.nan, 42.0])
+@parametrize_image_types
+@pytest.mark.parametrize("skip_nodata", [True, False])
+def test_nodata_output_set(
+    nodata_output: int | float, image_type: type[ImageType], skip_nodata: bool
+):
+    """Test that NoData in the image are filled or not."""
+    nodata_input = 0
+
+    # Encoded NoData and NaN should both be replaced across bands with the nodata_output
+    # value.
+    a = np.array([[[nodata_input, 1, np.nan]]])
+    expected_output = np.array([[[nodata_output, 1, nodata_output]]])
+
+    image = Image.from_image(wrap_image(a, type=image_type), nodata_input=0)
+    result = image.apply_ufunc_across_bands(
+        lambda x: x,
+        nodata_output=nodata_output,
+        skip_nodata=skip_nodata,
         output_dims=[["variable"]],
         output_sizes={"variable": a.shape[0]},
         output_dtypes=[a.dtype],
     )
 
-    assert_array_equal(unwrap_image(output), expected_output)
+    assert_array_equal(unwrap_image(result), expected_output)
+
+
+@parametrize_image_types
+@pytest.mark.parametrize("skip_nodata", [True, False])
+@pytest.mark.parametrize("nan_fill", [None, 42.0])
+def test_nan_filled(
+    image_type: type[ImageType], nan_fill: float | None, skip_nodata: bool
+):
+    """Test that NaNs in the image are filled before passing to func."""
+    a = np.array([[[1, np.nan]]])
+    image = Image.from_image(wrap_image(a, type=image_type))
+
+    def nan_check(x):
+        nonlocal nan_fill
+        if nan_fill is not None:
+            assert not np.isnan(x).any()
+
+        return x
+
+    result = image.apply_ufunc_across_bands(
+        nan_check,
+        skip_nodata=skip_nodata,
+        output_dims=[["variable"]],
+        output_sizes={"variable": a.shape[0]},
+        output_dtypes=[a.dtype],
+    )
+    # Unwrap to force computation for lazy arrays
+    unwrap_image(result)
 
 
 def test_skip_nodata_if_unneeded():
     """If an image is not float and nodata isn't specified, there should be no mask."""
     a = np.ones((3, 2, 2), dtype=int)
-    image = Image.from_image(a, nodata_vals=None)
+    image = Image.from_image(a, nodata_input=None)
 
-    assert image.nodata_vals is None
-
-
-@pytest.mark.parametrize("nodata", [99, np.nan])
-def test_nodata_masked_in_all_bands(nodata):
-    """If one band is NoData, those pixels should be masked in all bands."""
-    # Build an array with one band filled with NoData
-    a = np.ones((3, 8, 8))
-    a[1, ...] = nodata
-
-    # The output should be fully masked because missing values are broadcast to all
-    # bands in the output.
-    expected_output = np.full((3, 8, 8), np.nan)
-
-    image = Image.from_image(a, nodata_vals=nodata)
-
-    output = image.apply_ufunc_across_bands(
-        func=lambda x: x,
-        mask_nodata=True,
-        output_dims=[["variable"]],
-    )
-
-    assert_array_equal(output, expected_output)
+    assert image.nodata_input is None
 
 
-@pytest.mark.parametrize("nodata_vals", ["test", {}, False], ids=type)
-def test_nodata_validates_type(nodata_vals):
+@pytest.mark.parametrize("nodata_input", ["test", {}, False], ids=type)
+def test_nodata_validates_type(nodata_input):
     """Test that invalid NoData types are recognized."""
     a = np.zeros((3, 2, 2))
 
-    with pytest.raises(TypeError, match=f"Invalid type `{type(nodata_vals).__name__}`"):
-        Image.from_image(a, nodata_vals=nodata_vals)
+    with pytest.raises(
+        TypeError, match=f"Invalid type `{type(nodata_input).__name__}`"
+    ):
+        Image.from_image(a, nodata_input=nodata_input)
 
 
 def test_nodata_validates_length():
@@ -109,7 +147,7 @@ def test_nodata_validates_length():
     a = np.zeros((n_bands, 2, 2))
 
     with pytest.raises(ValueError, match=f"Expected {n_bands} NoData values but got 1"):
-        Image.from_image(a, nodata_vals=[-32768])
+        Image.from_image(a, nodata_input=[-32768])
 
 
 def test_nodata_single_value():
@@ -118,43 +156,43 @@ def test_nodata_single_value():
     nodata_val = -32768
     a = np.zeros((n_bands, 2, 2))
 
-    image = Image.from_image(a, nodata_vals=nodata_val)
-    assert image.nodata_vals.tolist() == [nodata_val] * n_bands
+    image = Image.from_image(a, nodata_input=nodata_val)
+    assert image.nodata_input.tolist() == [nodata_val] * n_bands
 
 
 def test_nodata_multiple_values():
     """Test that multiple NoData values are correctly stored."""
     n_bands = 3
-    nodata_vals = [-32768, 0, 255]
+    nodata_input = [-32768, 0, 255]
     a = np.zeros((n_bands, 2, 2))
 
-    image = Image.from_image(a, nodata_vals=nodata_vals)
-    assert image.nodata_vals.tolist() == nodata_vals
+    image = Image.from_image(a, nodata_input=nodata_input)
+    assert image.nodata_input.tolist() == nodata_input
 
 
-@pytest.mark.parametrize("nodata_vals", [None, -32768])
-def test_nodata_dataarray_fillvalue(nodata_vals):
+@pytest.mark.parametrize("nodata_input", [None, -32768])
+def test_nodata_dataarray_fillvalue(nodata_input):
     """Test that a _FillValue in a DataArray is broadcast if NoData is not provided."""
     n_bands = 3
     fill_val = -99
 
     da = xr.DataArray(np.ones((n_bands, 2, 2))).assign_attrs({"_FillValue": fill_val})
-    image = Image.from_image(da, nodata_vals=nodata_vals)
+    image = Image.from_image(da, nodata_input=nodata_input)
 
-    # _FillValue should be ignored if nodata_vals is provided
-    if nodata_vals is not None:
-        assert image.nodata_vals.tolist() == [nodata_vals] * n_bands
+    # _FillValue should be ignored if nodata_input is provided
+    if nodata_input is not None:
+        assert image.nodata_input.tolist() == [nodata_input] * n_bands
     else:
-        assert image.nodata_vals.tolist() == [fill_val] * n_bands
+        assert image.nodata_input.tolist() == [fill_val] * n_bands
 
 
 @pytest.mark.parametrize(
-    "nodata_vals", [None, -32768], ids=["without_nodata", "with_nodata"]
+    "nodata_input", [None, -32768], ids=["without_nodata", "with_nodata"]
 )
 @pytest.mark.parametrize(
     "fill_vals", [[1, 2, 3], [None, 1, None]], ids=["no_nones", "some_nones"]
 )
-def test_nodata_dataset_some_fillvalues(nodata_vals, fill_vals):
+def test_nodata_dataset_some_fillvalues(nodata_input, fill_vals):
     """Test that band-wise _FillValues are applied if some exist"""
     n_bands = 3
     das = [xr.DataArray(np.ones((n_bands, 2, 2))) for i in range(n_bands)]
@@ -164,34 +202,34 @@ def test_nodata_dataset_some_fillvalues(nodata_vals, fill_vals):
         das[i] = das[i].assign_attrs({"_FillValue": fill_val}).rename(i)
 
     ds = xr.merge(das)
-    image = Image.from_image(ds, nodata_vals=nodata_vals)
+    image = Image.from_image(ds, nodata_input=nodata_input)
 
-    # _FillValue should be ignored if nodata_vals is provided
-    if nodata_vals is not None:
-        assert image.nodata_vals.tolist() == [nodata_vals] * n_bands
+    # _FillValue should be ignored if nodata_input is provided
+    if nodata_input is not None:
+        assert image.nodata_input.tolist() == [nodata_input] * n_bands
     # Nodata vals should match the fill values, even if some are None
     else:
-        assert image.nodata_vals.tolist() == fill_vals
+        assert image.nodata_input.tolist() == fill_vals
 
 
 @pytest.mark.parametrize(
-    "nodata_vals", [None, -32768], ids=["without_nodata", "with_nodata"]
+    "nodata_input", [None, -32768], ids=["without_nodata", "with_nodata"]
 )
-def test_nodata_dataset_global_fillvalue(nodata_vals):
+def test_nodata_dataset_global_fillvalue(nodata_input):
     """Test that a global _FillValue is broadcast if per-band don't exist."""
     n_bands = 3
     global_fill_val = 42
     das = [xr.DataArray(np.ones((n_bands, 2, 2))).rename(i) for i in range(n_bands)]
 
     ds = xr.merge(das).assign_attrs({"_FillValue": global_fill_val})
-    image = Image.from_image(ds, nodata_vals=nodata_vals)
+    image = Image.from_image(ds, nodata_input=nodata_input)
 
-    # _FillValue should be ignored if nodata_vals is provided
-    if nodata_vals is not None:
-        assert image.nodata_vals.tolist() == [nodata_vals] * n_bands
+    # _FillValue should be ignored if nodata_input is provided
+    if nodata_input is not None:
+        assert image.nodata_input.tolist() == [nodata_input] * n_bands
     # The global fill value should be used when per-band fill values are unavailable
     else:
-        assert image.nodata_vals.tolist() == [global_fill_val] * n_bands
+        assert image.nodata_input.tolist() == [global_fill_val] * n_bands
 
 
 @parametrize_image_types

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -17,7 +17,7 @@ from .image_utils import (
 )
 
 
-@parametrize_image_types
+@parametrize_image_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
 def test_input_array_not_mutated(image_type: type[ImageType], skip_nodata: bool):
     """Ensure that applying a ufunc to an image doesn't mutate the original array."""
@@ -38,7 +38,7 @@ def test_input_array_not_mutated(image_type: type[ImageType], skip_nodata: bool)
     assert_array_equal(array, original_array)
 
 
-@parametrize_image_types
+@parametrize_image_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
 @pytest.mark.parametrize("val_dtype", [(-1, np.uint8), (np.nan, np.int16)])
 def test_nodata_output_with_unsupported_dtype(
@@ -68,7 +68,7 @@ def test_nodata_output_with_unsupported_dtype(
 
 
 @pytest.mark.parametrize("nodata_output", [np.nan, 42.0])
-@parametrize_image_types
+@parametrize_image_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
 def test_nodata_output_set(
     nodata_output: int | float, image_type: type[ImageType], skip_nodata: bool
@@ -94,7 +94,7 @@ def test_nodata_output_set(
     assert_array_equal(unwrap_image(result), expected_output)
 
 
-@parametrize_image_types
+@parametrize_image_types()
 def test_prevent_empty_array(image_type: type[ImageType]):
     """Test that funcs are not passed empty arrays if flag is set."""
     a = np.array([[[np.nan, np.nan, np.nan]]])
@@ -118,7 +118,7 @@ def test_prevent_empty_array(image_type: type[ImageType]):
 
 @pytest.mark.parametrize("num_valid", [0, 1, 3])
 @pytest.mark.parametrize("nodata_input", [-32768, np.nan])
-@parametrize_image_types
+@parametrize_image_types()
 def test_nodata_is_skipped(
     num_valid: int, nodata_input: int | float, image_type: type[ImageType]
 ):
@@ -145,7 +145,7 @@ def test_nodata_is_skipped(
     unwrap_image(result)
 
 
-@parametrize_image_types
+@parametrize_image_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
 @pytest.mark.parametrize("nan_fill", [None, 42.0])
 def test_nan_filled(
@@ -283,7 +283,7 @@ def test_nodata_dataset_global_fillvalue(nodata_input):
         assert image.nodata_input.tolist() == [global_fill_val] * n_bands
 
 
-@parametrize_image_types
+@parametrize_image_types()
 def test_wrappers(image_type):
     """Confirm that the test wrappers function as expected."""
     array = np.random.rand(3, 32, 16)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -69,19 +69,21 @@ def test_nodata_output_with_unsupported_dtype(
 
 @parametrize_image_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
-@pytest.mark.parametrize("val_dtype", [(-1, np.uint8), (np.nan, np.int16)])
+@pytest.mark.parametrize(
+    "val_dtypes", [(-1, np.uint8, np.int8), (np.nan, np.int16, np.float64)]
+)
 def test_nodata_output_with_allow_cast(
-    val_dtype: tuple[int | float, np.dtype],
+    val_dtypes: tuple[int | float, np.dtype, np.dtype],
     image_type: type[ImageType],
     skip_nodata: bool,
 ):
-    """Test that an unsupported nodata_output value causes a cast if allowed."""
+    """Test that an unsupported nodata_output value correctly casts if allowed."""
     # Make sure there's a value to mask in the input array
     a = np.array([[[np.nan]]])
     img = wrap_image(a, type=image_type)
     image = Image.from_image(img, nodata_input=0)
 
-    output_nodata, output_dtype = val_dtype
+    output_nodata, output_dtype, expected_dtype = val_dtypes
     # Unwrap to force computation for lazy arrays
     result = unwrap_image(
         image.apply_ufunc_across_bands(
@@ -95,7 +97,7 @@ def test_nodata_output_with_allow_cast(
         )
     )
 
-    assert result.dtype == type(output_nodata)
+    assert result.dtype == expected_dtype
 
 
 @pytest.mark.parametrize("nodata_output", [np.nan, 42.0])


### PR DESCRIPTION
Closes #39 and closes #40.

@grovduck, I tried to detail all the changes below, but as usual for me this snowballed into a bigger PR than I was hoping. This mostly follows the changes we discussed in the issues, but I deviated in a few places once I got deeper into it (e.g. using an adjustable `ensure_min_samples` instead of just `prevent_empty_array` and adding `allow_cast` rather than always erroring for out-of-bounds NoData output values).

Just to get a quick demo of some of the new features, you can use the code snippet below and experiment with the mask threshold and different `skip_nodata` and `nodata_output` parameters:

```python
from sklearn_raster.datasets import load_swo_ecoplot
from sklearn_raster import wrap
from sknnr import GNNRegressor


X_img, X, y = load_swo_ecoplot(as_dataset=True, large_rasters=False)
# Artificially mask some pixels
X_img_masked = X_img.where(X_img.TC2 >= 180)

est = wrap(GNNRegressor()).fit(X, y)

est.predict(X_img_masked, skip_nodata=True, nodata_output=np.nan).PSME_COV.plot()
```

Any feedback would be appreciated, but in particular if you have any thoughts on default parameters or if you see combinations of parameters/data that aren't tested or might be problematic, that would be a huge help.

## Parameter changes

This PR adds and modifies several parameters for `predict`, `kneighbors`, and the upstream apply functions.

### Added

1. `skip_nodata=True` only passes valid samples to the applied function by skipping NoData and NaN. The performance improvement scales pretty linearly with the proportion of NoData pixels in an image, so it's a huge speedup when you're working with heavily masked rasters.
2. `ensure_min_samples` passes a minimum number of dummy values to the applied function when `skip_nodata=True`, in case an image (or chunk of an image) is completely masked and a function requires a certain number of samples, e.g. some `sklearn` predictors. Currently this uses `nan_fill` if it's given as the dummy value and defaults to 0 otherwise. We could add a separate parameter for this, but I'm not sure if that's worth the effort since the point of `nan_fill` is to give  safe placeholder input to the function already?
3. `nodata_output` sets the fill value in the output image which is used to replace NoData and NaN pixels in the input image, and set `_FillValue` metadata for Xarray images. When the value doesn't fit the output array dtype, an error is raised by default.
4. `allow_cast=True` casts the output array to fit the `nodata_output`, instead of raising an error. This uses the minimum dtype for integers or `float64` for floats (unless `nodata_output` is explicitly cast as another float type).
5. `check_output_for_nodata=True` warns when an applied ufunc returns the specified `nodata_output` value, since that might indicate that valid pixels are masked. 

### Modified

1. `nodata_values`, which controls which values in the input array are treated as NoData, was renamed to `nodata_input` for symmetry with `nodata_output`. 
2. `nan_fill` no longer has any impact on the output array, and is used only to safely fill NaN inputs (if they're not being skipped) and provide a dummy input for `ensure_min_samples`.

### Removed

1. `mask_nodata=False` allowed the return value of applying the function to NoData values to be kept in the output, rather than setting a NoData fill value. This was incompatible with `skip_nodata=True` (there's no return value since we skip them) and unlikely to ever be the desired behavior. It can be recreated by not specifying `nodata_input`, if it was desired for some reason.

## Other changes

1. `_ImageChunk`, which handles the low-level flattening, masking, and NoData skipping when applying ufuncs to arrays, was split into a separate `ufunc` module for organization and renamed to `UfuncArrayProcessor`. My thinking was that while this class does store an image chunk, that's secondary to the main purpose which is processing ufuncs over the array, but I'm still not sure this is the best name.
2. Several functions have to postprocess the output of ufuncs that may be single arrays or tuples of arrays (to support `kneighbors`). To remove the complexity of handling that separately in each case, I added the `map_function_over_tuples` and `map_method_over_tuples` decorators which convert functions/methods to automatically map over tuples.
3. The `parametrize_image_types` test utility now allows you to specify a subset of types to test. I didn't end up using this, but I left it in because it might be useful in the future for testing over just Xarray images.

Here's the updated processing diagram (simplified since it doesn't include `ensure_min_samples` or `allow_cast`).

![image](https://github.com/user-attachments/assets/7d906e2d-4cf6-4e87-890f-01672d07000f)
