### PR TITLE
Refactor flattening

### DIFF
--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -10,6 +10,7 @@ from numpy.typing import NDArray
 
 from .types import ArrayUfunc, ImageType, NoDataType
 from .ufunc import UfuncArrayProcessor
+from .utils.image import image_to_samples
 from .utils.wrapper import map_method_over_tuples
 
 
@@ -82,8 +83,8 @@ class Image(Generic[ImageType], ABC):
                 k: list(range(s)) for k, s in output_sizes.items()
             }
 
+        @image_to_samples
         def ufunc(x):
-            x = self._preprocess_ufunc_input(x)
             return UfuncArrayProcessor(x, nodata_input=self.nodata_input).apply(
                 func,
                 skip_nodata=skip_nodata,
@@ -97,7 +98,7 @@ class Image(Generic[ImageType], ABC):
 
         result = xr.apply_ufunc(
             ufunc,
-            self.image,
+            self._preprocess_ufunc_input(self.image),
             dask="parallelized",
             input_core_dims=[[self.band_dim_name]],
             exclude_dims=set((self.band_dim_name,)),

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -9,7 +9,7 @@ import xarray as xr
 from numpy.typing import NDArray
 
 from .types import ArrayUfunc, ImageType, NoDataType
-from .ufunc import UfuncArrayProcessor
+from .ufunc import UfuncSampleProcessor
 from .utils.image import image_to_samples
 from .utils.wrapper import map_method_over_tuples
 
@@ -85,7 +85,7 @@ class Image(Generic[ImageType], ABC):
 
         @image_to_samples
         def ufunc(x):
-            return UfuncArrayProcessor(x, nodata_input=self.nodata_input).apply(
+            return UfuncSampleProcessor(x, nodata_input=self.nodata_input).apply(
                 func,
                 skip_nodata=skip_nodata,
                 nodata_output=nodata_output,

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -19,11 +19,6 @@ class UfuncSampleProcessor:
     1. Fills NaN samples in the input array.
     2. Passes valid samples to the ufunc.
     3. Masks NoData values in the ufunc output.
-
-    Notes
-    -----
-    To apply ufuncs to images, wrap them using the
-    `sklearn_raster.utils.image.image_to_samples` decorator.
     """
 
     feature_dim = -1

--- a/src/sklearn_raster/utils/image.py
+++ b/src/sklearn_raster/utils/image.py
@@ -63,11 +63,11 @@ def image_to_samples(
 
     @wraps(func)
     def wrapper(image: NDArray, *args, **kwargs) -> MaybeTuple[NDArray]:
-        result = func(image.reshape(-1, image.shape[-1], copy=False), *args, **kwargs)
+        result = func(image.reshape(-1, image.shape[-1]), *args, **kwargs)
 
         @map_function_over_tuples
         def unflatten(r: NDArray) -> NDArray:
-            return r.reshape(*image.shape[:2], -1, copy=False)
+            return r.reshape(*image.shape[:2], -1)
 
         return unflatten(result)
 

--- a/src/sklearn_raster/utils/image.py
+++ b/src/sklearn_raster/utils/image.py
@@ -3,10 +3,11 @@ from typing import Callable
 
 import numpy as np
 import xarray as xr
+from numpy.typing import NDArray
 from typing_extensions import Any, Concatenate
 
-from ..types import RT, ImageType, P
-from .wrapper import GenericWrapper
+from ..types import RT, ImageType, MaybeTuple, P
+from .wrapper import GenericWrapper, map_function_over_tuples
 
 
 def is_image_type(X: Any) -> bool:
@@ -32,5 +33,42 @@ def image_or_fallback(
             return getattr(self._wrapped, func.__name__)(X_image, *args, **kwargs)
 
         return func(self, X_image, *args, **kwargs)
+
+    return wrapper
+
+
+def image_to_samples(
+    func: Callable[Concatenate[NDArray, P], MaybeTuple[NDArray]],
+) -> Callable[Concatenate[NDArray, P], MaybeTuple[NDArray]]:
+    """
+    Decorator that flattens input images to samples and unflattens results to images.
+
+    Parameters
+    ----------
+    func : Callable
+        The decorated function that takes an array of shape (samples, features) and
+        returns one or more arrays of the same shape.
+
+    Returns
+    -------
+    Callable
+        The decorated function that instead takes an image of shape (y, x, bands) and
+        returns one or more images of the same shape.
+
+    Notes
+    -----
+    The dimension order (y, x, band) matches the chunks passed by `xarray.apply_ufunc`,
+    rather than the (band, y, x) order used by rasterio.
+    """
+
+    @wraps(func)
+    def wrapper(image: NDArray, *args, **kwargs) -> MaybeTuple[NDArray]:
+        result = func(image.reshape(-1, image.shape[-1], copy=False), *args, **kwargs)
+
+        @map_function_over_tuples
+        def unflatten(r: NDArray) -> NDArray:
+            return r.reshape(*image.shape[:2], -1, copy=False)
+
+        return unflatten(result)
 
     return wrapper


### PR DESCRIPTION
This closes #42 by making `UfuncSampleProcessor` (formerly `UfuncArrayProcessor`) work directly with arrays of samples, with the flattening of images to samples and unflattening of samples back to images now handled by the `image_to_samples` decorator.

I also did a little more refactoring and renaming throughout, mostly to make the `ufunc` module more clearly focused on samples rather than images. The refactoring of some of the `apply` logic into `_apply_to_all_samples` was unrelated, but hopefully makes it more clear that there are two parallel paths that branch out from `apply` with either `_apply_to_all_samples` or `_apply_to_valid_samples` (formerly `_skip_nodata_apply`) depending on the `skip_nodata` parameter.

@grovduck, since this was your good idea and you had some potential sample-based applications in mind, I'd love any feedback on the design decisions and whether you think this will fit your needs. We can always add more sample-focused functionality in the future if we decide that's in scope, but I want to make sure we're starting with a reasonably solid foundation at least.

I'm also open to any naming suggestions, particularly for `UfuncSampleProcessor`. Now that the flattening/unflattening is refactored out, the class is pretty focused on handling NoData (filling NaNs, skipping NoData samples, masking NoData outputs), so maybe the naming should reflect that? I couldn't come up with anything that encapsulates handling NoData + applying ufuncs to samples without getting too wordy, but maybe something will occur to you.