### PR TITLE
Create new hatch shell for `sklearn-raster[tutorials]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ datasets = [
 ]
 tutorials = [
     "sklearn-raster[datasets]",
+    "ipykernel",
     "matplotlib",
 ]
 
@@ -51,7 +52,6 @@ include = ["/src"]
 [tool.hatch.envs.default]
 dependencies = [
     "pre-commit",
-    "ipykernel",
     "sklearn-raster[datasets]",
 ]
 
@@ -60,6 +60,11 @@ dependencies = [
     "pytest",
     "pytest-cov",
     "sklearn-raster[datasets]",
+]
+
+[tool.hatch.envs.tutorials]
+dependencies = [
+    "sklearn-raster[tutorials]",
 ]
 
 [tool.hatch.envs.test.scripts]


### PR DESCRIPTION
Closes #44.

This PR creates a new hatch environment called `tutorials` which tracks the optional `sklearn[tutorials]` dependency.  Along with `sklearn[datasets]`, the sklearn[tutorials]` dependency installs:
- ipykernel
- matplotlib

This hatch environment will be useful for running tutorials to be developed as part of this package.  As part of this PR, `ipykernel` has been removed as a dependency of the default hatch environment and instead exists as a dependency of `sklearn[tutorials]`. 