### PR TITLE
Fix bug with ufuncs that squeeze the feature dimension

### DIFF
--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -211,6 +211,11 @@ class UfuncSampleProcessor:
                 check_output_for_nodata=check_output_for_nodata,
             )
 
+            # Ensure that the result has a feature dimension in case it was squeezed by
+            # the ufunc. `atleast_2d` adds the new axis at the index 0, so transpose
+            # twice to move it to the end.
+            result = np.atleast_2d(result.T).T
+
             # Build an output array pre-masked with the fill value and cast to the
             # output dtype. The shape will be (n, f) where n is the number of samples
             # in the array and f is the number of features in the func result.

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -129,7 +129,7 @@ def test_nodata_output_set(
 
 @pytest.mark.parametrize("n_bands", [1, 2])
 @parametrize_image_types()
-def test_ufunc_squeezes_dimension(n_bands: int, image_type: type[ImageType]):
+def test_shape_when_ufunc_squeezes_dimension(n_bands: int, image_type: type[ImageType]):
     """Test the output shape when a ufunc squeezes the feature dimension."""
     nodata_input = 0
     nodata_output = -99

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -127,6 +127,31 @@ def test_nodata_output_set(
     assert_array_equal(unwrap_image(result), expected_output)
 
 
+@pytest.mark.parametrize("n_bands", [1, 2])
+@parametrize_image_types()
+def test_ufunc_squeezes_dimension(n_bands: int, image_type: type[ImageType]):
+    """Test the output shape when a ufunc squeezes the feature dimension."""
+    nodata_input = 0
+    nodata_output = -99
+
+    # Insert at least one NoData value to trigger sample skipping
+    a = np.full((n_bands, 3, 3), 1)
+    a[0, 0, 0] = nodata_input
+
+    image = Image.from_image(wrap_image(a, type=image_type), nodata_input=nodata_input)
+    result = image.apply_ufunc_across_bands(
+        # Squeeze out the feature dimension (like a single-output predict method would)
+        lambda x: x.mean(axis=1, keepdims=False),
+        nodata_output=nodata_output,
+        skip_nodata=True,
+        output_dims=[["variable"]],
+        output_sizes={"variable": 1},
+        output_dtypes=[a.dtype],
+    )
+
+    assert unwrap_image(result).shape == (1, 3, 3)
+
+
 @parametrize_image_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
 def test_warn_when_ufunc_returns_nodata(image_type: type[ImageType], skip_nodata: bool):


### PR DESCRIPTION
We use `result.shape[-1]` to get the number of features when populating a result array within `_apply_to_valid_samples` (below), but this will be incorrect if `result` is 1D because the ufunc squeezed out the feature dimension, which will happen with some single-output `predict` methods or a reducer with `keepdims=False`.

https://github.com/lemma-osu/sklearn-raster/blob/3ac85aa4f60bfe7fb8da8a03f28c63e556285e5a/src/sklearn_raster/ufunc.py#L217-L221

To fix that, we just need to "unsqueeze" the second dimension. Unfortunately `atleast_2d` doesn't take an `axis` argument and always adds the new axis at the start instead of the end, so I'm using [this weird transpose workaround](https://github.com/numpy/numpy/issues/12336#issuecomment-1982970589) that leaves 2D arrays unchanged but adds a new second dimension for 1D arrays.

## Reproducing the bug

The code below reproduces the bug that this fixes.

```python
nodata_input = 0

# Insert at least one NoData value to trigger sample skipping
a = np.full((3, 3, 3), 1)
a[0, 0, 0] = nodata_input

image = Image.from_image(a, nodata_input=nodata_input)
result = image.apply_ufunc_across_bands(
    # Squeeze out the feature dimension (like a single-output predict method would)
    lambda x: x.mean(axis=1, keepdims=False),
    skip_nodata=True,
    output_dims=[["variable"]],
)

result.shape # (8, 3, 3) instead of (1, 3, 3)
```