### PR TITLE
Support wrapped methods with n-dimensional data

### DIFF
--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -12,7 +12,6 @@ from typing_extensions import Literal, overload
 from .image import Image
 from .types import EstimatorType
 from .utils.estimator import is_fitted, suppress_feature_name_warnings
-from .utils.image import image_or_fallback
 from .utils.wrapper import AttrWrapper, check_wrapper_implements
 
 if TYPE_CHECKING:
@@ -132,7 +131,6 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         return self
 
     @check_wrapper_implements
-    @image_or_fallback
     def predict(
         self,
         X_image: ImageType,
@@ -147,11 +145,6 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
     ) -> ImageType:
         """
         Predict target(s) for X_image.
-
-        Notes
-        -----
-        If X_image is not an image, the estimator's unmodified predict method will be
-        called instead.
 
         Parameters
         ----------
@@ -219,7 +212,6 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         )
 
     @check_wrapper_implements
-    @image_or_fallback
     @overload
     def kneighbors(
         self,
@@ -237,7 +229,6 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
     ) -> ImageType: ...
 
     @check_wrapper_implements
-    @image_or_fallback
     @overload
     def kneighbors(
         self,
@@ -255,7 +246,6 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
     ) -> tuple[ImageType, ImageType]: ...
 
     @check_wrapper_implements
-    @image_or_fallback
     def kneighbors(
         self,
         X_image: ImageType,
@@ -274,11 +264,6 @@ class ImageEstimator(AttrWrapper[EstimatorType]):
         Find the K-neighbors of each pixel in an image.
 
         Returns indices of and distances to the neighbors for each pixel.
-
-        Notes
-        -----
-        If X_image is not an image, the estimator's unmodified kneighbors method will be
-        called instead.
 
         Parameters
         ----------

--- a/src/sklearn_raster/image.py
+++ b/src/sklearn_raster/image.py
@@ -163,14 +163,14 @@ class NDArrayImage(Image):
     def _preprocess_ufunc_input(self, image: NDArray) -> NDArray:
         """Preprocess the image by transposing to (y, x, band) for apply_ufunc."""
         # Copy to avoid mutating the original image
-        return image.copy().transpose(1, 2, 0)
+        return np.moveaxis(image.copy(), 0, -1)
 
     @map_method_over_tuples
     def _postprocess_ufunc_output(
         self, result: NDArray, *, nodata_output: float | int, output_coords=None
     ) -> NDArray:
         """Postprocess the ufunc output by transposing back to (band, y, x)."""
-        return result.transpose(2, 0, 1)
+        return np.moveaxis(result, -1, 0)
 
 
 class DataArrayImage(Image):

--- a/src/sklearn_raster/utils/image.py
+++ b/src/sklearn_raster/utils/image.py
@@ -1,40 +1,11 @@
 from functools import wraps
 from typing import Callable
 
-import numpy as np
-import xarray as xr
 from numpy.typing import NDArray
-from typing_extensions import Any, Concatenate
+from typing_extensions import Concatenate
 
-from ..types import RT, ImageType, MaybeTuple, P
-from .wrapper import GenericWrapper, map_function_over_tuples
-
-
-def is_image_type(X: Any) -> bool:
-    # Feature array images must have exactly 3 dimensions: (y, x, band) or (band, y, x)
-    if isinstance(X, (np.ndarray, xr.DataArray)):
-        return X.ndim == 3
-
-    # Feature Dataset images must have exactly 2 dimensions: (x, y)
-    if isinstance(X, xr.Dataset):
-        return len(X.dims) == 2
-
-    return False
-
-
-def image_or_fallback(
-    func: Callable[Concatenate[GenericWrapper, ImageType, P], RT],
-) -> Callable[Concatenate[GenericWrapper, ImageType, P], RT]:
-    """Decorator that calls the wrapped method for non-image X arrays."""
-
-    @wraps(func)
-    def wrapper(self: GenericWrapper, X_image: ImageType, *args, **kwargs):
-        if not is_image_type(X_image):
-            return getattr(self._wrapped, func.__name__)(X_image, *args, **kwargs)
-
-        return func(self, X_image, *args, **kwargs)
-
-    return wrapper
+from ..types import MaybeTuple, P
+from .wrapper import map_function_over_tuples
 
 
 def image_to_samples(
@@ -67,7 +38,7 @@ def image_to_samples(
 
         @map_function_over_tuples
         def unflatten(r: NDArray) -> NDArray:
-            return r.reshape(*image.shape[:2], -1)
+            return r.reshape(*image.shape[:-1], -1)
 
         return unflatten(result)
 

--- a/tests/image_utils.py
+++ b/tests/image_utils.py
@@ -10,6 +10,10 @@ from numpy.typing import NDArray
 
 from sklearn_raster.types import ImageType
 
+# Dimension names to use when building Xarray images, in order of increasing
+# dimensionality, excluding the first "variable" dimension.
+EXTRA_DIM_NAMES = ["x", "y", "z", "time"]
+
 
 def parametrize_image_types(
     label="image_type",
@@ -176,7 +180,20 @@ def parametrize_model_data(
 
 def wrap_image(image: NDArray, type: type[ImageType]) -> ImageType:
     """
-    Wrap a Numpy NDArray image (y, x, bands) into the specified type.
+    Wrap a Numpy NDArray with features in the first dimension into the specified type.
+
+    Parameters
+    ----------
+    image : NDArray
+        The array to wrap, with features in the first dimension and between 1 and 4
+        additional dimensions, from (features, samples) up to (features, time, z, y, x).
+    type : type
+        The desired image type, either np.ndarray, xr.DataArray, or xr.Dataset.
+
+    Returns
+    -------
+    ImageType
+        The image in the desired format.
 
     Examples
     --------
@@ -205,9 +222,16 @@ def wrap_image(image: NDArray, type: type[ImageType]) -> ImageType:
         n_bands = image.shape[0]
         band_names = [f"b{i}" for i in range(n_bands)]
 
+        if 2 > image.ndim > 5:
+            raise ValueError("Image dimensionality must be between 2 and 5.")
+
+        # Include other dimensions in reverse order, following typical NetCDF
+        # conventions (e.g. time, z, y, x).
+        dims = ["variable"] + EXTRA_DIM_NAMES[: image.ndim - 1][::-1]
+
         return xr.DataArray(
             image,
-            dims=["variable", "y", "x"],
+            dims=dims,
             coords={"variable": band_names},
         ).chunk("auto")
 

--- a/tests/image_utils.py
+++ b/tests/image_utils.py
@@ -222,7 +222,7 @@ def wrap_image(image: NDArray, type: type[ImageType]) -> ImageType:
         n_bands = image.shape[0]
         band_names = [f"b{i}" for i in range(n_bands)]
 
-        if 2 > image.ndim > 5:
+        if image.ndim < 2 or image.ndim > 5:
             raise ValueError("Image dimensionality must be between 2 and 5.")
 
         # Include other dimensions in reverse order, following typical NetCDF

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -203,8 +203,9 @@ def test_with_non_image_data(model_data: ModelData):
     ref_dist, ref_nn = estimator.kneighbors(X)
 
     wrapped = wrap(clone(estimator)).fit(X, y)
-    # 1D arrays must be in (features, samples) shape to match the expected
-    # input
+    # Dataframes and derived 1D arrays are in (samples, features) by default, but
+    # wrapped estimators require features as the first dimension, hence the need to
+    # transpose the input and output.
     check_pred = wrapped.predict(X.T)
     check_dist, check_nn = wrapped.kneighbors(X.T)
 


### PR DESCRIPTION
This should close #48 by allowing wrapped methods like `predict` and `kneighbors` to support numpy and Xarray data with arbitrary dimensionality (including 1D), as long as the band/feature is the first dimension (or the variable for an `xr.Dataset`). 

@grovduck, I'm opening this as a draft since there are some design decisions to make and docstrings to update, and I'm not confident we won't turn up an edge case that breaks everything (this seemed way too easy). Do you mind testing this with your [1D example](https://github.com/lemma-osu/sklearn-raster/pull/45#issuecomment-2714575838) to make sure this works like you expect? If you use a Numpy array, you'll probably need to transpose it as a dataframe is stored (samples, features) instead of (features, samples). If you convert the dataframe with `to_xarray`, that should automatically transpose to the right order.

For higher-dimensionality prediction, I've been using the contrived example code below that just duplicates data to create a `time` dimension:

```python
from sknnr import GNNRegressor
import xarray as xr

from sklearn_raster import wrap
from sklearn_raster.datasets import load_swo_ecoplot


X_img, X, y = load_swo_ecoplot(as_dataset=True)

# Mask some values in the image
X_img = X_img.where(X_img["DEM"] > 550)

est = wrap(GNNRegressor()).fit(X, y)

# Add a time dimension to each variable
expanded_vars = {
    var: X_img[var].expand_dims(time=np.arange(3))
    for var in X_img.data_vars
}

X_img = xr.Dataset(expanded_vars)

pred = est.predict(X_img)
pred.PSME_COV.sel(time=1).plot()
```

## Design decisions

The big one is our usage of the term "image" throughout the package, e.g. `sklearn_raster.image.Image.from_image`, which feels a little limited if we now support n-dimensional data. We could use "raster" and/or "NDRaster" to tie it more closely to the package name, but it feels slightly odd to refer to 1D data as a raster. Any thoughts or other alternatives that come to mind for you?

We also refer a lot to data with `(band, y, x)` dimensionality, which is still probably the most common case but no longer the only supported case. We could update that to `(band, ...)` or even `(feature, ...)`, or just refer more generically to something like "arrays with bands/features as the first dimension", but I'm not sure how much we want to compromise between common usage and accuracy.

Any thoughts/opinions/ideas would be appreciated, but we can also kick this down the road and leave n-dimensional support as an undocumented feature for now and revisit later.

EDIT: I requested a review out of habit, but it's probably not worth your effort to do a full code review until we have some more confidence that it's working correctly and decide how we want to handle the terminology.