### PR TITLE
Update precommit hooks to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.2
+    rev: v0.11.2
     hooks:
       - id: ruff
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         exclude: ^tests/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def dummy_model_data():
     n_features = 5
     n_rows = 10


### PR DESCRIPTION
@grovduck pointed out that we're breaking [PT001](https://docs.astral.sh/ruff/rules/pytest-fixture-incorrect-parentheses-style/) according to recent ruff releases. This updates ruff and mypy to the latest releases and fixes that issue.