### PR TITLE
Expand errors when `nodata_output` doesn't fit in the array dtype

### DIFF
--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .types import ArrayUfunc, MaybeTuple
+from .utils.features import get_minimum_precise_numeric_dtype
 from .utils.wrapper import map_function_over_tuples
 
 
@@ -250,13 +251,7 @@ class UfuncSampleProcessor:
         Cast (if allowed) or raise if not. Also optionally check for NoData values in
         the output that may indicate valid samples being masked.
         """
-        # Use the minimum dtype for integers. Otherwise, just use the value's type to
-        # avoid casting to low-precision float16.
-        nodata_output_type = (
-            np.min_scalar_type(nodata_output)
-            if np.issubdtype(type(nodata_output), np.integer)
-            else type(nodata_output)
-        )
+        nodata_output_type = get_minimum_precise_numeric_dtype(nodata_output)
 
         if not np.can_cast(nodata_output_type, output.dtype):
             if allow_cast:

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -262,7 +262,7 @@ class UfuncSampleProcessor:
                     f"({nodata_output_type}) does not fit in the array dtype "
                     f"({output.dtype}). "
                 )
-                if nodata_output_type.kind == "f" and output.dtype.kind == "f":
+                if nodata_output_type.kind == output.dtype.kind == "f":
                     msg += (
                         "Consider casting `nodata_output` to a lower precision or set "
                         "`allow_cast=True` to automatically cast the output."

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -258,10 +258,21 @@ class UfuncSampleProcessor:
                 output = output.astype(nodata_output_type)
             else:
                 msg = (
-                    f"The selected `nodata_output` value {nodata_output} does not fit "
-                    f"in the array dtype {output.dtype}. Choose a different value or "
-                    "set `allow_cast=True` to automatically cast the output."
+                    f"The selected `nodata_output` value {nodata_output} "
+                    f"({nodata_output_type}) does not fit in the array dtype "
+                    f"({output.dtype}). "
                 )
+                if nodata_output_type.kind == "f" and output.dtype.kind == "f":
+                    msg += (
+                        "Consider casting `nodata_output` to a lower precision or set "
+                        "`allow_cast=True` to automatically cast the output."
+                    )
+                else:
+                    msg += (
+                        "Consider choosing a different `nodata_output` value or set "
+                        "`allow_cast=True` to automatically cast the output."
+                    )
+
                 raise ValueError(msg)
 
         if (

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -264,8 +264,8 @@ class UfuncSampleProcessor:
                 )
                 if nodata_output_type.kind == output.dtype.kind == "f":
                     msg += (
-                        "Consider casting `nodata_output` to a lower precision or set "
-                        "`allow_cast=True` to automatically cast the output."
+                        "Consider casting `nodata_output` to a lower precision float "
+                        "or set `allow_cast=True` to automatically cast the output."
                     )
                 else:
                     msg += (

--- a/src/sklearn_raster/utils/features.py
+++ b/src/sklearn_raster/utils/features.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from functools import wraps
 from typing import Callable
 
+import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import Concatenate
 
@@ -43,3 +46,17 @@ def reshape_to_samples(
         return unflatten(result)
 
     return wrapper
+
+
+def get_minimum_precise_numeric_dtype(value: int | float) -> np.dtype:
+    """
+    Get the minimum numeric dtype for a value without reducing precision.
+
+    Integers will return the smallest integer type that can hold the value, while floats
+    will return their current precision.
+    """
+    return (
+        np.min_scalar_type(value)
+        if np.issubdtype(type(value), np.integer)
+        else np.dtype(type(value))
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from sklearn_raster.utils.features import get_minimum_precise_numeric_dtype
+
+
+def test_minimum_precise_numeric_dtype():
+    """Test that correct minimum precise numeric dtypes are returned."""
+    # Integers should return the smallest dtype that can hold the value
+    assert get_minimum_precise_numeric_dtype(1) == np.uint8
+    assert get_minimum_precise_numeric_dtype(-1) == np.int8
+    assert get_minimum_precise_numeric_dtype(256) == np.uint16
+
+    # Floats should return their current precision
+    assert get_minimum_precise_numeric_dtype(42.0) == np.float64
+    assert get_minimum_precise_numeric_dtype(np.float32(np.nan)) == np.float32


### PR DESCRIPTION
Closes #53. This expands the error message when `nodata_output` doesn't fit in the array dtype returned by the ufunc to specify the detected dtype of the chosen value. For example, instead of `value nan does not fit in the array dtype float32` you'll now get `value nan (float64) does not fit in the array dtype (float32)`.

I also modified the error to provide a different suggested fix if the value and array are both floats. In that case, the error will suggest casting to a lower precision rather than choosing a different value.

Lastly, I refactored the logic of choosing the dtype for `nodata_output` into a util function so that it can be used in tests.

@grovduck, let me know what you think about the updated error message suggestions, and if they could be clearer or more explicit. Also, I threw `get_minimum_precise_numeric_dtype` into the `utils.features` module, but that didn't feel like a great fit...