### PR TITLE
Implement `predict_proba`

### DIFF
--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -153,7 +153,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             The n-dimensional input features. Array types should be in the shape
             (features, ...) while xr.Dataset should include features as variables.
             Features should correspond with those used to fit the estimator.
-        skip_nodata : bool, default=False
+        skip_nodata : bool, default=True
             If True, NoData and NaN values will be skipped during prediction. This
             speeds up processing of partially masked arrays, but may be incompatible if
             estimators expect a consistent number of input samples.
@@ -236,7 +236,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             The n-dimensional input features. Array types should be in the shape
             (features, ...) while xr.Dataset should include features as variables.
             Features should correspond with those used to fit the estimator.
-        skip_nodata : bool, default=False
+        skip_nodata : bool, default=True
             If True, NoData and NaN values will be skipped during prediction. This
             speeds up processing of partially masked arrays, but may be incompatible if
             estimators expect a consistent number of input samples.
@@ -314,7 +314,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         *,
         n_neighbors: int | None = None,
         return_distance: Literal[False] = False,
-        skip_nodata: bool = False,
+        skip_nodata: bool = True,
         nodata_input: NoDataType = None,
         nodata_output: float | int = -2147483648,
         ensure_min_samples: int = 1,
@@ -331,7 +331,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         *,
         n_neighbors: int | None = None,
         return_distance: Literal[True] = True,
-        skip_nodata: bool = False,
+        skip_nodata: bool = True,
         nodata_input: NoDataType = None,
         nodata_output: float | int = -2147483648,
         ensure_min_samples: int = 1,
@@ -347,7 +347,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         *,
         n_neighbors: int | None = None,
         return_distance: bool = True,
-        skip_nodata: bool = False,
+        skip_nodata: bool = True,
         nodata_input: NoDataType = None,
         nodata_output: float | int = -2147483648,
         ensure_min_samples: int = 1,
@@ -372,7 +372,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         return_distance : bool, default=True
             If True, return distances to the neighbors of each sample. If False, return
             indices only.
-        skip_nodata : bool, default=False
+        skip_nodata : bool, default=True
             If True, NoData and NaN values will be skipped during prediction. This
             speeds up processing of partially masked features, but may be incompatible
             if estimators expect a consistent number of input samples.

--- a/tests/feature_utils.py
+++ b/tests/feature_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generic
+from typing import Any, Generic, Literal
 
 import numpy as np
 import pandas as pd
@@ -155,6 +155,7 @@ def parametrize_model_data(
     X=None,
     y=None,
     feature_array_types=(np.ndarray, xr.DataArray, xr.Dataset),
+    mode: Literal["regression", "classification"] = "regression",
 ):
     """Parametrize over multiple feature types with the same test data."""
     n_features = (
@@ -169,7 +170,10 @@ def parametrize_model_data(
     if X is None:
         X = np.random.rand(n_rows, n_features)
     if y is None:
-        y = np.random.rand(n_rows, n_targets)
+        if mode == "classification":
+            y = np.random.choice([0, 1], (n_rows, n_targets))
+        else:
+            y = np.random.rand(n_rows, n_targets)
 
     model_data = [ModelData(X_image, X, y, cls) for cls in feature_array_types]
 


### PR DESCRIPTION
Closes #47 by implementing the `predict_proba` method for wrapped classifiers. This is modified from `predict` (parameters and docstring are almost identical), with the addition of some validation and retrieving output target names/count from the estimator's [`classes_` attribute](https://scikit-learn.org/stable/glossary.html#term-classes_). In #47 I mentioned those could be stored in `FittedMetadata`, but it turns out there's no need since they're accessible from the estimator.

With a single-output classifier, `predict_proba` will return an array of shape `(n_classes, ...)` or a `Dataset` with classes as variables. Multi-output is not supported (details further down).

@grovduck, any feedback appreciated as usual! The tests aren't particularly exhaustive and I shoehorned classification into the testing framework just to get some quick coverage. Inspired by your work on `sknnr`, I think a next step might be to implement some regression testing here so I can confirm more than just output shapes, but I'll leave that for another day.

EDIT: This also makes an unrelated fix to set the default `skip_nodata=True` parameter for `kneighbors`.

## Example Usage

```python
from sklearn_raster import wrap
from sklearn_raster.datasets import load_swo_ecoplot
from sklearn.ensemble import RandomForestClassifier


X_img, X, y = load_swo_ecoplot(as_dataset=True)

# Convert to a binary classification target based on majority PSME cover
y = y.idxmax(axis=1).eq("PSME_COV").astype(int)

est = wrap(RandomForestClassifier()).fit(X, y)
prob = est.predict_proba(X_img)

# Probability of class 1 (majority PSME)
prob[1].plot()
```

## Multi-output support

With an unmodified multi-output estimator, `predict_proba` can return a tuple with one array per classification target. For example, if you trained on one binary classification target and another multi-class target and predicted probability for 100 samples, you could get an output of shape `((100, 2), (100, 10))`.  

While `xr.apply_ufunc` supports tuple outputs (like `kneighbors`), it does *not* support output dimensions that vary in size between outputs, as far as I can tell. The code below is a minimal example showing why that doesn't work, as `output_sizes` must map the output dimension to the dimension size, and only supports a single value.

```python
arr = np.random.random((3, 16))
da = xr.DataArray(
    arr,
    dims=["variable", "samples"],
    coords={"variable": [1, 2, 3], "samples": np.arange(arr.shape[1])},
).chunk("auto")

xr.apply_ufunc(
    # Return arrays with different-sized `class` dimension
    lambda x: (x, x[:, :2]),
    da,
    input_core_dims=[["variable"]],
    exclude_dims=set(("variable",)),
    output_core_dims=[["class"], ["class"]],
    dask="parallelized",
    dask_gufunc_kwargs={
        # All outputs must have the same size `class` dimension
        "output_sizes": {"class": 3}
    },
)[1].compute()
```

Multi-output classification seems like a pretty niche application, so I'm not too worried about being unable to support that.