### PR TITLE
Support multiple `nodata_output` values

### DIFF
--- a/src/sklearn_raster/datasets/_base.py
+++ b/src/sklearn_raster/datasets/_base.py
@@ -67,18 +67,18 @@ def _load_rasters_to_array(file_paths: list[Path]) -> NDArray:
 
 @overload
 def load_swo_ecoplot(
-    as_dataset: Literal[True],
-    large_rasters: bool = False,
-    chunks: Any = None,
-) -> tuple[xr.Dataset, pd.DataFrame, pd.DataFrame]: ...
-
-
-@overload
-def load_swo_ecoplot(
     as_dataset: Literal[False] = False,
     large_rasters: bool = False,
     chunks: Any = None,
 ) -> tuple[NDArray, pd.DataFrame, pd.DataFrame]: ...
+
+
+@overload
+def load_swo_ecoplot(
+    as_dataset: Literal[True] = True,
+    large_rasters: bool = False,
+    chunks: Any = None,
+) -> tuple[xr.Dataset, pd.DataFrame, pd.DataFrame]: ...
 
 
 def load_swo_ecoplot(

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -313,23 +313,6 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         X: FeatureArrayType,
         *,
         n_neighbors: int | None = None,
-        return_distance: Literal[False] = False,
-        skip_nodata: bool = True,
-        nodata_input: NoDataType = None,
-        nodata_output: float | int | None = None,
-        ensure_min_samples: int = 1,
-        allow_cast: bool = False,
-        check_output_for_nodata: bool = True,
-        **kneighbors_kwargs,
-    ) -> FeatureArrayType: ...
-
-    @check_wrapper_implements
-    @overload
-    def kneighbors(
-        self,
-        X: FeatureArrayType,
-        *,
-        n_neighbors: int | None = None,
         return_distance: Literal[True] = True,
         skip_nodata: bool = True,
         nodata_input: NoDataType = None,
@@ -339,6 +322,23 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         check_output_for_nodata: bool = True,
         **kneighbors_kwargs,
     ) -> tuple[FeatureArrayType, FeatureArrayType]: ...
+
+    @check_wrapper_implements
+    @overload
+    def kneighbors(
+        self,
+        X: FeatureArrayType,
+        *,
+        n_neighbors: int | None = None,
+        return_distance: Literal[False] = False,
+        skip_nodata: bool = True,
+        nodata_input: NoDataType = None,
+        nodata_output: float | int | None = None,
+        ensure_min_samples: int = 1,
+        allow_cast: bool = False,
+        check_output_for_nodata: bool = True,
+        **kneighbors_kwargs,
+    ) -> FeatureArrayType: ...
 
     @check_wrapper_implements
     def kneighbors(

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -418,6 +418,9 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         """
         if nodata_output is None:
             nodata_output = (np.nan, -2147483648) if return_distance else -2147483648
+        elif return_distance is False and isinstance(nodata_output, (tuple, list)):
+            msg = "`nodata_output` must be a scalar when `return_distance` is False."
+            raise ValueError(msg)
 
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
         k = n_neighbors or cast(int, getattr(self._wrapped, "n_neighbors", 5))

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import pandas as pd
     from numpy.typing import NDArray
 
-    from .types import FeatureArrayType, NoDataType
+    from .types import FeatureArrayType, MaybeTuple, NoDataType
 
 ESTIMATOR_OUTPUT_DTYPES: dict[str, np.dtype] = {
     "classifier": np.int32,
@@ -333,7 +333,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         return_distance: Literal[True] = True,
         skip_nodata: bool = True,
         nodata_input: NoDataType = None,
-        nodata_output: float | int = -2147483648,
+        nodata_output: MaybeTuple[float | int] = (np.nan, -2147483648),
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
@@ -349,7 +349,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         return_distance: bool = True,
         skip_nodata: bool = True,
         nodata_input: NoDataType = None,
-        nodata_output: float | int = -2147483648,
+        nodata_output: MaybeTuple[float | int] = -2147483648,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
@@ -381,10 +381,12 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             will be broadcast to all features while sequences of values will be assigned
             feature-wise. If None, values will be inferred if possible based on
             available metadata.
-        nodata_output : float or int, default np.nan
+        nodata_output : float or int or tuple of floats or ints, default -2147483648
             NoData samples in the input features will be replaced with this value in the
             output targets. If the value does not fit the array dtype returned by the
-            estimator, an error will be raised unless `allow_cast` is True.
+            estimator, an error will be raised unless `allow_cast` is True. If
+            `return_distance` is True, you can provide a tuple of two values to use
+            for distances and indexes, respectively.
         ensure_min_samples : int, default 1
             The minimum number of samples that should be passed to `kneighbors`. If the
             array is fully masked and `skip_nodata=True`, dummy values (0) will be

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -316,7 +316,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         return_distance: Literal[False] = False,
         skip_nodata: bool = True,
         nodata_input: NoDataType = None,
-        nodata_output: float | int = -2147483648,
+        nodata_output: float | int | None = None,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
@@ -333,7 +333,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         return_distance: Literal[True] = True,
         skip_nodata: bool = True,
         nodata_input: NoDataType = None,
-        nodata_output: MaybeTuple[float | int] = (np.nan, -2147483648),
+        nodata_output: MaybeTuple[float | int] | None = None,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
@@ -349,7 +349,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         return_distance: bool = True,
         skip_nodata: bool = True,
         nodata_input: NoDataType = None,
-        nodata_output: MaybeTuple[float | int] = -2147483648,
+        nodata_output: MaybeTuple[float | int] | None = None,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
@@ -381,12 +381,13 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             will be broadcast to all features while sequences of values will be assigned
             feature-wise. If None, values will be inferred if possible based on
             available metadata.
-        nodata_output : float or int or tuple of floats or ints, default -2147483648
+        nodata_output : float or int or tuple, optional
             NoData samples in the input features will be replaced with this value in the
             output targets. If the value does not fit the array dtype returned by the
             estimator, an error will be raised unless `allow_cast` is True. If
             `return_distance` is True, you can provide a tuple of two values to use
-            for distances and indexes, respectively.
+            for distances and indexes, respectively. Defaults to np.nan for the distance
+            array and -2147483648 for the neighbor array.
         ensure_min_samples : int, default 1
             The minimum number of samples that should be passed to `kneighbors`. If the
             array is fully masked and `skip_nodata=True`, dummy values (0) will be
@@ -415,6 +416,9 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             Array types will be in the shape (neighbor, ...) while xr.Dataset will store
             neighbors as variables.
         """
+        if nodata_output is None:
+            nodata_output = (np.nan, -2147483648) if return_distance else -2147483648
+
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
         k = n_neighbors or cast(int, getattr(self._wrapped, "n_neighbors", 5))
 

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -8,7 +8,7 @@ import numpy as np
 import xarray as xr
 from numpy.typing import NDArray
 
-from .types import ArrayUfunc, FeatureArrayType, NoDataType
+from .types import ArrayUfunc, FeatureArrayType, MaybeTuple, NoDataType
 from .ufunc import UfuncSampleProcessor
 from .utils.features import reshape_to_samples
 from .utils.wrapper import map_over_arguments
@@ -71,7 +71,7 @@ class FeatureArray(Generic[FeatureArrayType], ABC):
         output_sizes: dict[str, int] | None = None,
         output_coords: dict[str, list[str | int]] | None = None,
         skip_nodata: bool = True,
-        nodata_output: float | int = np.nan,
+        nodata_output: MaybeTuple[float | int] = np.nan,
         nan_fill: float | int | None = None,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
@@ -126,7 +126,7 @@ class FeatureArray(Generic[FeatureArrayType], ABC):
         return features
 
     @abstractmethod
-    @map_over_arguments("result")
+    @map_over_arguments("result", "nodata_output")
     def _postprocess_ufunc_output(
         self,
         result: FeatureArrayType,
@@ -207,7 +207,7 @@ class DataArrayFeatures(FeatureArray):
 
         return None
 
-    @map_over_arguments("result")
+    @map_over_arguments("result", "nodata_output")
     def _postprocess_ufunc_output(
         self,
         result: xr.DataArray,
@@ -262,7 +262,7 @@ class DatasetFeatures(DataArrayFeatures):
         # Fall back to the DataArray logic for handling NoData
         return super()._validate_nodata_input(nodata_input)
 
-    @map_over_arguments("result")
+    @map_over_arguments("result", "nodata_output")
     def _postprocess_ufunc_output(
         self,
         result: xr.DataArray,

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -11,7 +11,7 @@ from numpy.typing import NDArray
 from .types import ArrayUfunc, FeatureArrayType, NoDataType
 from .ufunc import UfuncSampleProcessor
 from .utils.features import reshape_to_samples
-from .utils.wrapper import map_method_over_tuples
+from .utils.wrapper import map_over_arguments
 
 
 class FeatureArray(Generic[FeatureArrayType], ABC):
@@ -114,7 +114,9 @@ class FeatureArray(Generic[FeatureArrayType], ABC):
         )
 
         return self._postprocess_ufunc_output(
-            result, output_coords=output_coords, nodata_output=nodata_output
+            result=result,
+            output_coords=output_coords,
+            nodata_output=nodata_output,
         )
 
     def _preprocess_ufunc_input(self, features: FeatureArrayType) -> FeatureArrayType:
@@ -124,7 +126,7 @@ class FeatureArray(Generic[FeatureArrayType], ABC):
         return features
 
     @abstractmethod
-    @map_method_over_tuples
+    @map_over_arguments("result")
     def _postprocess_ufunc_output(
         self,
         result: FeatureArrayType,
@@ -170,7 +172,7 @@ class NDArrayFeatures(FeatureArray):
         # Copy to avoid mutating the original array
         return np.moveaxis(features.copy(), 0, -1)
 
-    @map_method_over_tuples
+    @map_over_arguments("result")
     def _postprocess_ufunc_output(
         self, result: NDArray, *, nodata_output: float | int, output_coords=None
     ) -> NDArray:
@@ -205,7 +207,7 @@ class DataArrayFeatures(FeatureArray):
 
         return None
 
-    @map_method_over_tuples
+    @map_over_arguments("result")
     def _postprocess_ufunc_output(
         self,
         result: xr.DataArray,
@@ -260,7 +262,7 @@ class DatasetFeatures(DataArrayFeatures):
         # Fall back to the DataArray logic for handling NoData
         return super()._validate_nodata_input(nodata_input)
 
-    @map_method_over_tuples
+    @map_over_arguments("result")
     def _postprocess_ufunc_output(
         self,
         result: xr.DataArray,
@@ -270,7 +272,9 @@ class DatasetFeatures(DataArrayFeatures):
     ) -> xr.Dataset:
         """Process the ufunc output converting from DataArray to Dataset."""
         result = super()._postprocess_ufunc_output(
-            result, output_coords=output_coords, nodata_output=nodata_output
+            result=result,
+            output_coords=output_coords,
+            nodata_output=nodata_output,
         )
         var_dim = result.dims[self.feature_dim]
         ds = result.to_dataset(dim=var_dim)

--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -8,7 +8,7 @@ from numpy.typing import NDArray
 
 from .types import ArrayUfunc, MaybeTuple
 from .utils.features import get_minimum_precise_numeric_dtype
-from .utils.wrapper import map_function_over_tuples
+from .utils.wrapper import map_over_arguments
 
 
 class UfuncSampleProcessor:
@@ -149,7 +149,7 @@ class UfuncSampleProcessor:
     ) -> NDArray | tuple[NDArray, ...]:
         """Apply a function to all samples in an array."""
 
-        @map_function_over_tuples
+        @map_over_arguments("result")
         def mask_nodata(result: NDArray) -> NDArray:
             """Replace NoData values in the input array with `output_nodata`."""
             result = self._validate_nodata_output(
@@ -202,7 +202,7 @@ class UfuncSampleProcessor:
             # Temporarily disable the mask so that dummy samples aren't skipped
             nodata_mask[:ensure_min_samples] = False
 
-        @map_function_over_tuples
+        @map_over_arguments("result")
         def populate_missing_samples(result: NDArray) -> NDArray:
             """Insert the array result for valid samples into the full-shaped array."""
             result = self._validate_nodata_output(

--- a/src/sklearn_raster/utils/features.py
+++ b/src/sklearn_raster/utils/features.py
@@ -43,7 +43,7 @@ def reshape_to_samples(
         def unflatten(r: NDArray) -> NDArray:
             return r.reshape(*array.shape[:-1], -1)
 
-        return unflatten(r=result)
+        return unflatten(result)
 
     return wrapper
 

--- a/src/sklearn_raster/utils/features.py
+++ b/src/sklearn_raster/utils/features.py
@@ -8,7 +8,7 @@ from numpy.typing import NDArray
 from typing_extensions import Concatenate
 
 from ..types import MaybeTuple, P
-from .wrapper import map_function_over_tuples
+from .wrapper import map_over_arguments
 
 
 def reshape_to_samples(
@@ -39,11 +39,11 @@ def reshape_to_samples(
     def wrapper(array: NDArray, *args, **kwargs) -> MaybeTuple[NDArray]:
         result = func(array.reshape(-1, array.shape[-1]), *args, **kwargs)
 
-        @map_function_over_tuples
+        @map_over_arguments("r")
         def unflatten(r: NDArray) -> NDArray:
             return r.reshape(*array.shape[:-1], -1)
 
-        return unflatten(result)
+        return unflatten(r=result)
 
     return wrapper
 

--- a/tests/feature_utils.py
+++ b/tests/feature_utils.py
@@ -87,6 +87,10 @@ class ModelData(Generic[FeatureArrayType]):
         return self._X_image.shape[0]
 
     @property
+    def X_image_shape(self):
+        return self._X_image.shape
+
+    @property
     def X_image(self) -> FeatureArrayType:
         """Feature image."""
         return wrap_features(self._X_image, self._feature_array_type)

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -210,6 +210,14 @@ def test_kneighbors_nodata_outputs(model_data: ModelData):
     assert np.unique(unwrap_features(dist)) == [-32768]
     assert np.unique(unwrap_features(nn)) == [255]
 
+    expected_msg = "`nodata_output` must be a scalar when `return_distance` is False"
+    with pytest.raises(ValueError, match=expected_msg):
+        unwrap_features(
+            estimator.kneighbors(
+                X_image, return_distance=False, nodata_output=(np.nan, -32768)
+            )
+        )
+
 
 @parametrize_model_data(feature_array_types=(xr.DataArray,))
 def test_predict_dataarray_with_custom_dim_name(model_data: ModelData):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
+import re
+
 import numpy as np
+import pytest
 
 from sklearn_raster.utils.features import get_minimum_precise_numeric_dtype
+from sklearn_raster.utils.wrapper import map_over_arguments
 
 
 def test_minimum_precise_numeric_dtype():
@@ -13,3 +17,23 @@ def test_minimum_precise_numeric_dtype():
     # Floats should return their current precision
     assert get_minimum_precise_numeric_dtype(42.0) == np.float64
     assert get_minimum_precise_numeric_dtype(np.float32(np.nan)) == np.float32
+
+
+def test_map_over_arguments():
+    """Test that map_over_arguments decorator works as expected."""
+
+    @map_over_arguments("a", "b")
+    def func(a, b):
+        return a + b
+
+    assert func(1, 2) == 3
+    assert func(1, b=[2, 3]) == (3, 4)
+    assert func(a=[1, 2], b=[3, 4]) == (4, 6)
+
+
+def test_map_over_arguments_validation():
+    """Test that map_over_arguments raises for unaccepted arguments."""
+    with pytest.raises(ValueError, match=re.escape("cannot be mapped over: ['a']")):
+
+        @map_over_arguments("a")
+        def _(): ...

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,8 +27,11 @@ def test_map_over_arguments():
         return a + b
 
     assert func(1, 2) == 3
-    assert func(1, b=[2, 3]) == (3, 4)
+    assert func(1, [2, 3]) == (3, 4)
     assert func(a=[1, 2], b=[3, 4]) == (4, 6)
+
+    with pytest.raises(ValueError, match="must be the same length or scalar"):
+        func(a=[1, 2], b=[3, 4, 5])
 
 
 def test_map_over_arguments_validation():


### PR DESCRIPTION
Closes #43 by allowing users to specify different `nodata_output` values for the distance and neighbor grids returned by `kneighbors`. More generally, this enables multiple `nodata_output` values to be broadcast when an applied ufunc returns multiple arrays. This is implemented with the new `map_over_arguments` decorator that replaces `map_function_over_tuples` and `map_method_over_tuples` to support mapping over arbitrary named arguments instead of only the first or second positional argument, respectively.

From the issue:

> Once this is implemented, the default nodata_output for kneighbors should be revisited.

@grovduck, I'm currently still using `-2147483648` (the `int32` minimum) for the neighbor array and `np.nan` for the distance array, but I'm tempted to change the neighbor default to `-1` as the huge negative value makes outputs hard to visualize. I'm pretty sure an unmodified `kneighbors` can never return a negative index, so the only chance for a clash would be a custom `kneighbors` method like in `sknnr` combined with a dataframe index that includes negative values. That seems like a weird enough edge case that it's not worth worrying about to me (and the user would be warned about the clash anyways), but what do you think @grovduck? You've worked with a lot more real world plot data than I have, so let me know if I'm underestimating the likelihood of weird negative plot numbering.