### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,56 @@
+# Adapted from: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Publish to PyPI
+on:
+    push:
+        tags:
+            # Publish when a tag is pushed
+            - '*'
+
+jobs:
+    build:
+        name: Build distribution
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                persist-credentials: false
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: '3.x'
+
+            - name: Install hatch
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install hatch
+
+            - name: Build distribution
+              run: hatch build -c
+
+            - name: Store packages
+              uses: actions/upload-artifact@v4
+              with:
+                name: python-package-distributions
+                path: dist/
+                    
+    publish-to-pypi:
+        name: Publish to PyPI
+        runs-on: ubuntu-latest
+        needs:
+        - build
+        environment:
+            name: pypi
+            url: https://pypi.org/p/sklearn-raster
+        permissions:
+            id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+        steps:
+        - name: Download dists
+          uses: actions/download-artifact@v4
+          with:
+            name: python-package-distributions
+            path: dist/
+        - name: Publish distribution to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,18 +32,21 @@ hatch run docs:serve
 hatch run docs:build
 ```
 
-## Publish
+## Releasing
 
-Increment versions with Hatch:
-
-```bash
-hatch version <patch|minor|major>
-```
-
-Build and publish with Hatch:
+First, use `hatch` to [update the version number](https://hatch.pypa.io/latest/version/#updating) in a new release branch and merge into `main`.
 
 ```bash
-hatch clean
-hatch build
-hatch publish
+$ hatch version [major|minor|patch|alpha|beta|rc|post|dev]
 ```
+
+Checkout `main` and confirm that it is up-to-date with the remote, including the bumped version. Finally, create and push the release tag.
+
+```bash
+$ git checkout main
+$ git pull
+$ git tag "$(hatch version)"
+$ git push --tags
+```
+
+Pushing the updated tag will trigger [a workflow](https://github.com/lemma-osu/sklearn-raster/actions/workflows/publish.yml) that publishes the release to PyPI.


### PR DESCRIPTION
See https://github.com/lemma-osu/sknnr/pull/93

I just copied the release section of the contributing guide from `sknnr` to keep them in sync.

Because we don't have a PyPI release for this project yet, Github is set up as a [pending publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/), which should allow it to create the initial PyPI release when we push the first tag.