### PR TITLE
Implement `transform` and `inverse_transform`

### DIFF
--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -492,9 +492,6 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         output_dim_name = "variable"
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
 
-        # TODO: How does sklearn handle this?
-        # self._check_feature_names(features.feature_names)
-
         # TODO: Think about this
         output_dtype = np.float64
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -11,8 +11,8 @@ from typing_extensions import Literal, overload
 
 from .features import FeatureArray
 from .types import EstimatorType
-from .utils.estimator import is_fitted, require_fitted, suppress_feature_name_warnings
-from .utils.wrapper import AttrWrapper, require_attributes, require_implementation
+from .utils.estimator import is_fitted, requires_fitted, suppress_feature_name_warnings
+from .utils.wrapper import AttrWrapper, requires_attributes, requires_implementation
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -90,7 +90,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         # Default to sequential identifiers
         return tuple(range(self._get_n_targets(y)))
 
-    @require_implementation
+    @requires_implementation
     def fit(self, X, y=None, **kwargs) -> FeatureArrayEstimator[EstimatorType]:
         """
         Fit an estimator from a training set (X, y).
@@ -130,8 +130,8 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
 
         return self
 
-    @require_implementation
-    @require_fitted
+    @requires_implementation
+    @requires_fitted
     def predict(
         self,
         X: FeatureArrayType,
@@ -214,9 +214,9 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             **predict_kwargs,
         )
 
-    @require_implementation
-    @require_fitted
-    @require_attributes("classes_")
+    @requires_implementation
+    @requires_fitted
+    @requires_attributes("classes_")
     def predict_proba(
         self,
         X: FeatureArrayType,
@@ -301,8 +301,8 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             **predict_proba_kwargs,
         )
 
-    @require_implementation
-    @require_fitted
+    @requires_implementation
+    @requires_fitted
     @overload
     def kneighbors(
         self,
@@ -319,8 +319,8 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         **kneighbors_kwargs,
     ) -> tuple[FeatureArrayType, FeatureArrayType]: ...
 
-    @require_implementation
-    @require_fitted
+    @requires_implementation
+    @requires_fitted
     @overload
     def kneighbors(
         self,
@@ -337,8 +337,8 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         **kneighbors_kwargs,
     ) -> FeatureArrayType: ...
 
-    @require_implementation
-    @require_fitted
+    @requires_implementation
+    @requires_fitted
     def kneighbors(
         self,
         X: FeatureArrayType,
@@ -442,9 +442,9 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             **kneighbors_kwargs,
         )
 
-    @require_implementation
-    @require_fitted
-    @require_attributes("get_feature_names_out")
+    @requires_implementation
+    @requires_fitted
+    @requires_attributes("get_feature_names_out")
     def transform(
         self,
         X: FeatureArrayType,
@@ -526,8 +526,8 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             **transform_kwargs,
         )
 
-    @require_implementation
-    @require_fitted
+    @requires_implementation
+    @requires_fitted
     def inverse_transform(
         self,
         X: FeatureArrayType,

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -458,13 +458,10 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
 
         self._check_feature_names(features.feature_names)
 
-        # TODO: Think about this
-        output_dtype = np.float64
-
         return features.apply_ufunc_across_features(
             suppress_feature_name_warnings(self._wrapped.transform),
             output_dims=[[output_dim_name]],
-            output_dtypes=[output_dtype],
+            output_dtypes=[np.float64],
             output_sizes={output_dim_name: len(feature_names)},
             output_coords={output_dim_name: list(feature_names)},
             skip_nodata=skip_nodata,
@@ -492,13 +489,10 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         output_dim_name = "variable"
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
 
-        # TODO: Think about this
-        output_dtype = np.float64
-
         return features.apply_ufunc_across_features(
             suppress_feature_name_warnings(self._wrapped.inverse_transform),
             output_dims=[[output_dim_name]],
-            output_dtypes=[output_dtype],
+            output_dtypes=[np.float64],
             output_sizes={output_dim_name: len(self._wrapped_meta.feature_names)},
             output_coords={output_dim_name: list(self._wrapped_meta.feature_names)},
             skip_nodata=skip_nodata,

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -6,12 +6,12 @@ from warnings import warn
 
 import numpy as np
 from sklearn.base import clone
-from sklearn.utils.validation import _get_feature_names, check_is_fitted
+from sklearn.utils.validation import _get_feature_names
 from typing_extensions import Literal, overload
 
 from .features import FeatureArray
 from .types import EstimatorType
-from .utils.estimator import is_fitted, suppress_feature_name_warnings
+from .utils.estimator import is_fitted, require_fitted, suppress_feature_name_warnings
 from .utils.wrapper import AttrWrapper, require_attributes, require_implementation
 
 if TYPE_CHECKING:
@@ -131,6 +131,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         return self
 
     @require_implementation
+    @require_fitted
     def predict(
         self,
         X: FeatureArrayType,
@@ -214,6 +215,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         )
 
     @require_implementation
+    @require_fitted
     @require_attributes("classes_")
     def predict_proba(
         self,
@@ -300,6 +302,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         )
 
     @require_implementation
+    @require_fitted
     @overload
     def kneighbors(
         self,
@@ -317,6 +320,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
     ) -> tuple[FeatureArrayType, FeatureArrayType]: ...
 
     @require_implementation
+    @require_fitted
     @overload
     def kneighbors(
         self,
@@ -334,6 +338,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
     ) -> FeatureArrayType: ...
 
     @require_implementation
+    @require_fitted
     def kneighbors(
         self,
         X: FeatureArrayType,
@@ -438,6 +443,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         )
 
     @require_implementation
+    @require_fitted
     @require_attributes("get_feature_names_out")
     def transform(
         self,
@@ -521,6 +527,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         )
 
     @require_implementation
+    @require_fitted
     def inverse_transform(
         self,
         X: FeatureArrayType,
@@ -599,7 +606,6 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
 
     def _check_feature_names(self, feature_array_names: NDArray) -> None:
         """Check that feature array names match feature names seen during fitting."""
-        check_is_fitted(self._wrapped)
         fitted_feature_names = self._wrapped_meta.feature_names
 
         no_fitted_names = len(fitted_feature_names) == 0

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -451,6 +451,53 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         check_output_for_nodata: bool = True,
         **transform_kwargs,
     ) -> FeatureArrayType:
+        """
+        Apply the transformation to n-dimensional X features.
+
+        Parameters
+        ----------
+        X : Numpy or Xarray features
+            The n-dimensional input features. Array types should be in the shape
+            (features, ...) while xr.Dataset should include features as variables.
+            Features should correspond with those used to fit the estimator.
+        skip_nodata : bool, default=True
+            If True, NoData and NaN values will be skipped during prediction. This
+            speeds up processing of partially masked features, but may be incompatible
+            if estimators expect a consistent number of input samples.
+        nodata_input : float or sequence of floats, optional
+            NoData values other than NaN to mask in the output features. A single value
+            will be broadcast to all features while sequences of values will be assigned
+            feature-wise. If None, values will be inferred if possible based on
+            available metadata.
+        nodata_output : float or int or tuple, optional
+            NoData samples in the input features will be replaced with this value in the
+            output features. If the value does not fit the array dtype returned by the
+            estimator, an error will be raised unless `allow_cast` is True. Defaults to
+            np.nan.
+        ensure_min_samples : int, default 1
+            The minimum number of samples that should be passed to `transform`. If the
+            array is fully masked and `skip_nodata=True`, dummy values (0) will be
+            inserted to ensure this number of samples. The minimum supported number of
+            samples depends on the estimator used. No effect if the array contains
+            enough unmasked samples or if `skip_nodata=False`.
+        allow_cast : bool, default=False
+            If True and the estimator output dtype is incompatible with the chosen
+            `nodata_output` value, the output will be cast to the correct dtype instead
+            of raising an error.
+        check_output_for_nodata : bool, default True
+            If True and `nodata_output` is not np.nan, a warning will be raised if the
+            selected `nodata_output` value is returned by the estimator, as this may
+            indicate a valid sample being masked.
+        **transform_kwargs
+            Additional arguments passed to the estimator's `transform` method.
+
+        Returns
+        -------
+        Numpy or Xarray features
+            The transformed features. Array types will be in the shape (features, ...)
+            while xr.Dataset will store features as variables, with the feature names
+            based on the estimator's `get_feature_names_out` method.
+        """
         feature_names = self._wrapped.get_feature_names_out()
 
         output_dim_name = "variable"
@@ -486,6 +533,52 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         check_output_for_nodata: bool = True,
         **inverse_transform_kwargs,
     ) -> FeatureArrayType:
+        """
+        Apply the inverse transformation to n-dimensional X features.
+
+        Parameters
+        ----------
+        X : Numpy or Xarray features
+            The n-dimensional input features. Array types should be in the shape
+            (features, ...) while xr.Dataset should include features as variables.
+            Features should correspond with those used to fit the estimator.
+        skip_nodata : bool, default=True
+            If True, NoData and NaN values will be skipped during prediction. This
+            speeds up processing of partially masked features, but may be incompatible
+            if estimators expect a consistent number of input samples.
+        nodata_input : float or sequence of floats, optional
+            NoData values other than NaN to mask in the output features. A single value
+            will be broadcast to all features while sequences of values will be assigned
+            feature-wise. If None, values will be inferred if possible based on
+            available metadata.
+        nodata_output : float or int or tuple, optional
+            NoData samples in the input features will be replaced with this value in the
+            output features. If the value does not fit the array dtype returned by the
+            estimator, an error will be raised unless `allow_cast` is True. Defaults to
+            np.nan.
+        ensure_min_samples : int, default 1
+            The minimum number of samples that should be passed to `transform`. If the
+            array is fully masked and `skip_nodata=True`, dummy values (0) will be
+            inserted to ensure this number of samples. The minimum supported number of
+            samples depends on the estimator used. No effect if the array contains
+            enough unmasked samples or if `skip_nodata=False`.
+        allow_cast : bool, default=False
+            If True and the estimator output dtype is incompatible with the chosen
+            `nodata_output` value, the output will be cast to the correct dtype instead
+            of raising an error.
+        check_output_for_nodata : bool, default True
+            If True and `nodata_output` is not np.nan, a warning will be raised if the
+            selected `nodata_output` value is returned by the estimator, as this may
+            indicate a valid sample being masked.
+        **transform_kwargs
+            Additional arguments passed to the estimator's `transform` method.
+
+        Returns
+        -------
+        Numpy or Xarray features
+            The inverse-transformed features. Array types will be in the shape
+            (features, ...) while xr.Dataset will store features as variables.
+        """
         output_dim_name = "variable"
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -104,7 +104,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             regression). Single-output targets of shape (n_samples, 1) will be squeezed
             to shape (n_samples,) to allow consistent prediction across all estimators.
         **kwargs : dict
-            Additional keyword arguments passed to the estimator's fit method, e.g.
+            Additional keyword arguments passed to the estimator's `fit` method, e.g.
             `sample_weight`.
 
         Returns
@@ -181,7 +181,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             selected `nodata_output` value is returned by the estimator, as this may
             indicate a valid sample being masked.
         **predict_kwargs
-            Additional arguments passed to the estimator's predict method.
+            Additional arguments passed to the estimator's `predict` method.
 
         Returns
         -------
@@ -266,7 +266,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             selected `nodata_output` value is returned by the estimator, as this may
             indicate a valid sample being masked.
         **predict_proba_kwargs
-            Additional arguments passed to the estimator's predict_proba method.
+            Additional arguments passed to the estimator's `predict_proba` method.
 
         Returns
         -------
@@ -401,7 +401,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             selected `nodata_output` value is returned by the estimator, as this may
             indicate a valid sample being masked.
         **kneighbors_kwargs
-            Additional arguments passed to the estimator's kneighbors method.
+            Additional arguments passed to the estimator's `kneighbors` method.
 
         Returns
         -------
@@ -577,8 +577,8 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and `nodata_output` is not np.nan, a warning will be raised if the
             selected `nodata_output` value is returned by the estimator, as this may
             indicate a valid sample being masked.
-        **transform_kwargs
-            Additional arguments passed to the estimator's `transform` method.
+        **inverse_transform_kwargs
+            Additional arguments passed to the estimator's `inverse_transform` method.
 
         Returns
         -------

--- a/src/sklearn_raster/utils/estimator.py
+++ b/src/sklearn_raster/utils/estimator.py
@@ -1,7 +1,12 @@
 import warnings
+from functools import wraps
+from typing import Callable, Concatenate
 
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
+
+from ..types import RT, P
+from .wrapper import GenericWrapper
 
 
 def is_fitted(estimator: BaseEstimator) -> bool:
@@ -21,5 +26,18 @@ def suppress_feature_name_warnings(func):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=msg)
             return func(*args, **kwargs)
+
+    return wrapper
+
+
+def require_fitted(
+    func: Callable[Concatenate[GenericWrapper, P], RT],
+) -> Callable[Concatenate[GenericWrapper, P], RT]:
+    """Decorator to check if an estimator is fitted before calling a method."""
+
+    @wraps(func)
+    def wrapper(self: GenericWrapper, *args, **kwargs):
+        check_is_fitted(self)
+        return func(self, *args, **kwargs)
 
     return wrapper

--- a/src/sklearn_raster/utils/estimator.py
+++ b/src/sklearn_raster/utils/estimator.py
@@ -31,7 +31,7 @@ def suppress_feature_name_warnings(func):
     return wrapper
 
 
-def require_fitted(
+def requires_fitted(
     func: Callable[Concatenate[GenericWrapper, P], RT],
 ) -> Callable[Concatenate[GenericWrapper, P], RT]:
     """Decorator to check if an estimator is fitted before calling a method."""

--- a/src/sklearn_raster/utils/estimator.py
+++ b/src/sklearn_raster/utils/estimator.py
@@ -1,9 +1,10 @@
 import warnings
 from functools import wraps
-from typing import Callable, Concatenate
+from typing import Callable
 
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
+from typing_extensions import Concatenate
 
 from ..types import RT, P
 from .wrapper import GenericWrapper

--- a/src/sklearn_raster/utils/wrapper.py
+++ b/src/sklearn_raster/utils/wrapper.py
@@ -26,16 +26,16 @@ class AttrWrapper(Generic[AnyType]):
 GenericWrapper = TypeVar("GenericWrapper", bound=AttrWrapper)
 
 
-def require_implementation(
+def requires_implementation(
     func: Callable[Concatenate[GenericWrapper, P], RT],
 ) -> Callable[Concatenate[GenericWrapper, P], RT]:
     """
     A decorator that raises if the wrapped instance doesn't implement the given method.
     """
-    return require_attributes(func.__name__)(func)
+    return requires_attributes(func.__name__)(func)
 
 
-def require_attributes(
+def requires_attributes(
     *attrs: str,
 ) -> Callable[
     [Callable[Concatenate[GenericWrapper, P], RT]],


### PR DESCRIPTION
This closes #16 by implementing `transform` and `inverse_transform` methods for compatible estimators like `StandardScaler` and `PCA`. Example usage:

```python
from sklearn.decomposition import PCA
from sklearn.preprocessing import StandardScaler
from sklearn.pipeline import make_pipeline
from sklearn_raster.datasets import load_swo_ecoplot
from sklearn_raster import wrap

X_img, X, y = load_swo_ecoplot(as_dataset=True)
pipeline = wrap(make_pipeline(
    StandardScaler(),
    PCA(n_components=3),
)).fit(X)

# Transform the image bands into principal components
components = pipeline.transform(X_img)
components.pca0.plot()

# Inverse transform the components back into bands
# (this won't match the original due to the reduced component dimensionality)
reconstructed = pipeline.inverse_transform(components)
reconstructed.NBR.plot()
```

The actual method implementations are pretty simple and infer output shapes based on `get_feature_names_out` (as originally suggested by @grovduck) for the forward transformation and the fitted features for the inverse transform. 

Because attribute validation is a common requirement for wrapped methods, I added a `require_attributes` decorator to simplify that process, which just checks that the wrapped estimator has the necessary attribute to allow implementation. That's a very similar check to the existing `check_wrapper_implements`, so I refactored and renamed that to `require_implementation`, which is just a special case of `require_attributes` that checks for the method attribute. 

EDIT: I've also added a `require_fitted` decorator to ensure that we don't get an unrelated attribute error when attempting to call a method on an unfitted estimator. The general validation process for a wrapped method like `transform` is now:

1. Does the estimator implement the method?
2. Is the estimator fitted?
3. Does the estimator have the necessary attributes?
