### PR TITLE
Fix `inverse_transform` generating empty `xr.Dataset` when fit without feature names

### DIFF
--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -593,7 +593,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
 
         feature_names = self._wrapped_meta.feature_names
         # If the estimator was fitted without feature names, use sequential integers
-        if len(feature_names) != self._wrapped_meta.n_features:
+        if not feature_names.size:
             feature_names = range(self._wrapped_meta.n_features)
 
         return features.apply_ufunc_across_features(

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -123,7 +123,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
 
         self._wrapped_meta = FittedMetadata(
             n_targets=self._get_n_targets(y),
-            n_features=self._get_n_targets(X),
+            n_features=X.shape[-1],
             target_names=self._get_target_names(y),
             feature_names=fitted_feature_names
             if fitted_feature_names is not None

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -32,6 +32,7 @@ class FittedMetadata:
     """Metadata from a fitted estimator."""
 
     n_targets: int
+    n_features: int
     target_names: tuple[str | int, ...]
     feature_names: NDArray
 
@@ -122,6 +123,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
 
         self._wrapped_meta = FittedMetadata(
             n_targets=self._get_n_targets(y),
+            n_features=self._get_n_targets(X),
             target_names=self._get_target_names(y),
             feature_names=fitted_feature_names
             if fitted_feature_names is not None
@@ -589,12 +591,17 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         output_dim_name = "variable"
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
 
+        feature_names = self._wrapped_meta.feature_names
+        # If the estimator was fitted without feature names, use sequential integers
+        if len(feature_names) != self._wrapped_meta.n_features:
+            feature_names = range(self._wrapped_meta.n_features)
+
         return features.apply_ufunc_across_features(
             suppress_feature_name_warnings(self._wrapped.inverse_transform),
             output_dims=[[output_dim_name]],
             output_dtypes=[np.float64],
-            output_sizes={output_dim_name: len(self._wrapped_meta.feature_names)},
-            output_coords={output_dim_name: list(self._wrapped_meta.feature_names)},
+            output_sizes={output_dim_name: self._wrapped_meta.n_features},
+            output_coords={output_dim_name: list(feature_names)},
             skip_nodata=skip_nodata,
             nodata_output=nodata_output,
             ensure_min_samples=ensure_min_samples,

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -521,7 +521,7 @@ def test_missing_required_attrs_raise(method: str, required_attr: str):
         f"implement `{method}`"
     )
     # Fit the estimator to avoid an immediate NotFittedError
-    est = wrap(DummyEstimator()).fit(None, None)
+    est = wrap(DummyEstimator()).fit(np.ones((1, 1)))
     with pytest.raises(NotImplementedError, match=expected):
         getattr(est, method)(None, None)
 

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -349,6 +349,42 @@ def test_predicted_var_names(model_data: ModelData, fit_with):
     assert list(var_names) == expected_var_names
 
 
+@pytest.mark.filterwarnings("ignore:.*fitted without feature names")
+@parametrize_model_data(feature_array_types=(xr.DataArray, xr.Dataset))
+@pytest.mark.parametrize(
+    "fit_with", [np.ndarray, pd.DataFrame], ids=lambda x: x.__name__
+)
+def test_transformed_var_names(model_data: ModelData, fit_with):
+    """
+    Test that variable names are correctly set in a Dataset or DataArray.
+    """
+    X_image, X, _ = model_data
+
+    # Models fitted without named features should inverse transform to sequential
+    # integer names
+    if fit_with is np.ndarray:
+        expected_inverted_names = list(range(model_data.n_features))
+        X = np.asarray(X)
+    # Models fitted with feature names should inverse transform back to those names
+    elif fit_with is pd.DataFrame:
+        expected_inverted_names = list(X.columns)
+
+    estimator = wrap(PCA(n_components=3)).fit(X)
+    components = estimator.transform(X_image)
+    inverted = estimator.inverse_transform(components)
+
+    if isinstance(X_image, xr.DataArray):
+        component_names = components["variable"].values
+        inverted_names = inverted["variable"].values
+    else:
+        component_names = components.data_vars
+        inverted_names = inverted.data_vars
+
+    expected_component_names = ["pca0", "pca1", "pca2"]
+    assert list(component_names) == expected_component_names
+    assert list(inverted_names) == expected_inverted_names
+
+
 @parametrize_model_data(
     feature_array_types=(xr.DataArray, xr.Dataset), mode="classification"
 )


### PR DESCRIPTION
When you fit a transformer with unnamed features (i.e. a Numpy array) and generate a named feature array (e.g. an `xr.Dataset`), `inverse_transform` should assign sequential numeric names `[0, 1, 2 ... n_features]`, similar to `predict`. This wasn't happening because it relied on `FittedMetadata.feature_names` which stores the *input* feature names, which will be an empty array in that case to facilitate the feature name check. As a result, the output feature array will be empty:

```python
from sklearn.preprocessing import StandardScaler
from sklearn_raster.datasets import load_swo_ecoplot
from sklearn_raster import wrap

X_img, X, y = load_swo_ecoplot(as_dataset=True)
scaler = wrap(StandardScaler()).fit(X.values, y)
print(scaler.inverse_transform(scaler.transform(X_img)).data_vars)
```
```
Data variables:
    *empty*
```

To solve that, we need to 1) store the number of features seen during fitting, and 2) generate sequential integers as the output feature names for `inverse_transform` when none are available. This implements and tests that solution.