### PR TITLE
Fix unserializable names

### DIFF
--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -69,7 +69,7 @@ class FeatureArray(Generic[FeatureArrayType], ABC):
         output_dims: list[list[str]],
         output_dtypes: list[np.dtype] | None = None,
         output_sizes: dict[str, int] | None = None,
-        output_coords: dict[str, list[str | int]] | None = None,
+        output_coords: dict[str, list[str] | list[int]] | None = None,
         skip_nodata: bool = True,
         nodata_output: MaybeTuple[float | int] = np.nan,
         nan_fill: float | int | None = None,

--- a/src/sklearn_raster/utils/estimator.py
+++ b/src/sklearn_raster/utils/estimator.py
@@ -42,3 +42,8 @@ def requires_fitted(
         return func(self, *args, **kwargs)
 
     return wrapper
+
+
+def generate_sequential_names(n: int, prefix: str) -> list[str]:
+    """Generate a list of `n` prefixed sequential names."""
+    return [f"{prefix}{i}" for i in range(n)]


### PR DESCRIPTION
Closes #63 

Previously, some wrapped methods would return integer variable names/coordinates (depending on whether you're using  `xr.Dataset` or `xr.DataArray`), which prevents serialization to NetCDF, Zarr, or GeoTIFF. This switches to descriptive string variables for all methods, and modifies the dimension names to match the coordinates for `xr.DataArray`. 

For example, `kneighbors` with an `xr.DataArray` would previously return dimension `k` with coordinates `[1, 2, ...]` and now returns dimension `neighbor` with coordinates `["neighbor0", "neighbor1", ...]`. Methods now return the following dimensions:

- `predict`: target
- `predict_proba`: class
- `kneighbors`: neighbor
- `transform`: feature
- `inverse_transform`: feature

We were also using a mix of types to store feature and target names including tuples and Numpy arrays, but they always needed to be cast to list as input to the ufunc. This now uses lists throughout.

@grovduck, let me know what you think about the more specific dimension names I used here. I figured these are more descriptive and match the coordinates nicely (e.g. `sel(target="target0")` instead of `sel(variable="target0")`, but using the generic "variable" dimension might be less surprising and wouldn't force you to remember which method corresponds to which dimension. I could go either way.
