### PR TITLE
Drop inherited attrs and set metadata attrs on estimator results

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install hatch
 
+      - name: Install test environment
+        run: |
+          hatch env create test
+          hatch -e test run pip freeze
+
       - name: Run tests
         run: hatch run test:all -n 4
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -216,6 +216,9 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            set_attrs={
+                "source_method": self._wrapped.__class__.__name__ + ".predict",
+            },
             **predict_kwargs,
         )
 
@@ -303,6 +306,9 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            set_attrs={
+                "source_method": self._wrapped.__class__.__name__ + ".predict_proba",
+            },
             **predict_proba_kwargs,
         )
 
@@ -450,6 +456,9 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            set_attrs={
+                "source_method": self._wrapped.__class__.__name__ + ".kneighbors",
+            },
             **kneighbors_kwargs,
         )
 
@@ -533,6 +542,9 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            set_attrs={
+                "source_method": self._wrapped.__class__.__name__ + ".transform",
+            },
             **transform_kwargs,
         )
 
@@ -618,6 +630,10 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            set_attrs={
+                "source_method": self._wrapped.__class__.__name__
+                + ".inverse_transform",
+            },
             **inverse_transform_kwargs,
         )
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -147,6 +147,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
+        keep_attrs: bool = False,
         **predict_kwargs,
     ) -> FeatureArrayType:
         """
@@ -185,6 +186,13 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and `nodata_output` is not np.nan, a warning will be raised if the
             selected `nodata_output` value is returned by the estimator, as this may
             indicate a valid sample being masked.
+        keep_attrs : bool, default=False
+            If True and the input is an Xarray object, the output will keep all
+            attributes of the input features, unless they're set by the estimator (e.g.
+            `_FillValue` or `long_name`). Note that some attributes (e.g.
+            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            default. The `history` attribute will always be kept. No effect if the
+            input is a Numpy array.
         **predict_kwargs
             Additional arguments passed to the estimator's `predict` method.
 
@@ -217,6 +225,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            keep_attrs=keep_attrs,
             **predict_kwargs,
         )
 
@@ -233,6 +242,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
+        keep_attrs: bool = False,
         **predict_proba_kwargs,
     ) -> FeatureArrayType:
         """
@@ -271,6 +281,13 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and `nodata_output` is not np.nan, a warning will be raised if the
             selected `nodata_output` value is returned by the estimator, as this may
             indicate a valid sample being masked.
+        keep_attrs : bool, default=False
+            If True and the input is an Xarray object, the output will keep all
+            attributes of the input features, unless they're set by the estimator (e.g.
+            `_FillValue` or `long_name`). Note that some attributes (e.g.
+            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            default. The `history` attribute will always be kept. No effect if the
+            input is a Numpy array.
         **predict_proba_kwargs
             Additional arguments passed to the estimator's `predict_proba` method.
 
@@ -305,6 +322,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            keep_attrs=keep_attrs,
             **predict_proba_kwargs,
         )
 
@@ -323,6 +341,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
+        keep_attrs: bool = False,
         **kneighbors_kwargs,
     ) -> tuple[FeatureArrayType, FeatureArrayType]: ...
 
@@ -341,6 +360,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
+        keep_attrs: bool = False,
         **kneighbors_kwargs,
     ) -> FeatureArrayType: ...
 
@@ -358,6 +378,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
+        keep_attrs: bool = False,
         **kneighbors_kwargs,
     ) -> FeatureArrayType | tuple[FeatureArrayType, FeatureArrayType]:
         """
@@ -407,6 +428,13 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and `nodata_output` is not np.nan, a warning will be raised if the
             selected `nodata_output` value is returned by the estimator, as this may
             indicate a valid sample being masked.
+        keep_attrs : bool, default=False
+            If True and the input is an Xarray object, the output will keep all
+            attributes of the input features, unless they're set by the estimator (e.g.
+            `_FillValue` or `long_name`). Note that some attributes (e.g.
+            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            default. The `history` attribute will always be kept. No effect if the
+            input is a Numpy array.
         **kneighbors_kwargs
             Additional arguments passed to the estimator's `kneighbors` method.
 
@@ -453,6 +481,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            keep_attrs=keep_attrs,
             **kneighbors_kwargs,
         )
 
@@ -469,6 +498,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
+        keep_attrs: bool = False,
         **transform_kwargs,
     ) -> FeatureArrayType:
         """
@@ -508,6 +538,13 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and `nodata_output` is not np.nan, a warning will be raised if the
             selected `nodata_output` value is returned by the estimator, as this may
             indicate a valid sample being masked.
+        keep_attrs : bool, default=False
+            If True and the input is an Xarray object, the output will keep all
+            attributes of the input features, unless they're set by the estimator (e.g.
+            `_FillValue` or `long_name`). Note that some attributes (e.g.
+            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            default. The `history` attribute will always be kept. No effect if the
+            input is a Numpy array.
         **transform_kwargs
             Additional arguments passed to the estimator's `transform` method.
 
@@ -537,6 +574,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            keep_attrs=keep_attrs,
             **transform_kwargs,
         )
 
@@ -552,6 +590,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
+        keep_attrs: bool = False,
         **inverse_transform_kwargs,
     ) -> FeatureArrayType:
         """
@@ -591,6 +630,13 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and `nodata_output` is not np.nan, a warning will be raised if the
             selected `nodata_output` value is returned by the estimator, as this may
             indicate a valid sample being masked.
+        keep_attrs : bool, default=False
+            If True and the input is an Xarray object, the output will keep all
+            attributes of the input features, unless they're set by the estimator (e.g.
+            `_FillValue` or `long_name`). Note that some attributes (e.g.
+            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            default. The `history` attribute will always be kept. No effect if the
+            input is a Numpy array.
         **inverse_transform_kwargs
             Additional arguments passed to the estimator's `inverse_transform` method.
 
@@ -623,6 +669,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
+            keep_attrs=keep_attrs,
             **inverse_transform_kwargs,
         )
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -190,7 +190,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and the input is an Xarray object, the output will keep all
             attributes of the input features, unless they're set by the estimator (e.g.
             `_FillValue` or `long_name`). Note that some attributes (e.g.
-            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            `scale_factor`) may become inaccurate, which is why they are dropped by
             default. The `history` attribute will always be kept. No effect if the
             input is a Numpy array.
         **predict_kwargs
@@ -285,7 +285,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and the input is an Xarray object, the output will keep all
             attributes of the input features, unless they're set by the estimator (e.g.
             `_FillValue` or `long_name`). Note that some attributes (e.g.
-            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            `scale_factor`) may become inaccurate, which is why they are dropped by
             default. The `history` attribute will always be kept. No effect if the
             input is a Numpy array.
         **predict_proba_kwargs
@@ -432,7 +432,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and the input is an Xarray object, the output will keep all
             attributes of the input features, unless they're set by the estimator (e.g.
             `_FillValue` or `long_name`). Note that some attributes (e.g.
-            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            `scale_factor`) may become inaccurate, which is why they are dropped by
             default. The `history` attribute will always be kept. No effect if the
             input is a Numpy array.
         **kneighbors_kwargs
@@ -542,7 +542,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and the input is an Xarray object, the output will keep all
             attributes of the input features, unless they're set by the estimator (e.g.
             `_FillValue` or `long_name`). Note that some attributes (e.g.
-            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            `scale_factor`) may become inaccurate, which is why they are dropped by
             default. The `history` attribute will always be kept. No effect if the
             input is a Numpy array.
         **transform_kwargs
@@ -634,7 +634,7 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             If True and the input is an Xarray object, the output will keep all
             attributes of the input features, unless they're set by the estimator (e.g.
             `_FillValue` or `long_name`). Note that some attributes (e.g.
-            `scale_factor`) may become inaccurate, which is why they are  dropped by
+            `scale_factor`) may become inaccurate, which is why they are dropped by
             default. The `history` attribute will always be kept. No effect if the
             input is a Numpy array.
         **inverse_transform_kwargs

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, cast
+from typing import TYPE_CHECKING, cast
 from warnings import warn
 
 import numpy as np
@@ -217,7 +217,6 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
-            set_attrs={"source_method": self._method_name(wrapped_func)},
             **predict_kwargs,
         )
 
@@ -306,7 +305,6 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
-            set_attrs={"source_method": self._method_name(wrapped_func)},
             **predict_proba_kwargs,
         )
 
@@ -455,7 +453,6 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
-            set_attrs={"source_method": self._method_name(wrapped_func)},
             **kneighbors_kwargs,
         )
 
@@ -540,7 +537,6 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
-            set_attrs={"source_method": self._method_name(wrapped_func)},
             **transform_kwargs,
         )
 
@@ -627,15 +623,8 @@ class FeatureArrayEstimator(AttrWrapper[EstimatorType]):
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             nan_fill=0.0,
-            set_attrs={
-                "source_method": self._method_name(wrapped_func),
-            },
             **inverse_transform_kwargs,
         )
-
-    def _method_name(self, func: Callable) -> str:
-        """Get the full method name of a wrapped function."""
-        return self._wrapped.__class__.__name__ + "." + func.__name__
 
     def _check_feature_names(self, feature_array_names: NDArray) -> None:
         """Check that feature array names match feature names seen during fitting."""

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -294,7 +294,7 @@ class DataArrayFeatures(FeatureArray):
             set_attrs.update(new_attrs)
 
         if keep_attrs:
-            return set_attrs | attrs
+            return attrs | set_attrs
 
         return set_attrs
 

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -231,8 +231,10 @@ class DataArrayFeatures(FeatureArray):
         # Transpose features from the last to the first dimension
         result = result.transpose(result.dims[-1], ...)
         # Drop top-level attributes from the input data, but retain coordinate attrs to
-        # preserve the spatial reference, if present.
-        result = result.drop_attrs(deep=False)
+        # preserve the spatial reference, if present. Note that we avoid using
+        # drop_attrs(deep=False) for backwards compatibility due to
+        # https://github.com/pydata/xarray/issues/10027
+        result.attrs = {}
         if set_attrs is not None:
             result.attrs.update(set_attrs)
         if not np.isnan(nodata_output):

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -221,12 +221,11 @@ class DataArrayFeatures(FeatureArray):
 
         # Transpose features from the last to the first dimension
         result = result.transpose(result.dims[-1], ...)
-
+        # Drop top-level attributes from the input data, but retain coordinate attrs to
+        # preserve the spatial reference, if present.
+        result = result.drop_attrs(deep=False)
         if not np.isnan(nodata_output):
             result.attrs["_FillValue"] = nodata_output
-        else:
-            # Remove the _FillValue copied from the input array
-            result.attrs.pop("_FillValue", None)
 
         return result
 
@@ -282,5 +281,6 @@ class DatasetFeatures(DataArrayFeatures):
         for var in ds.data_vars:
             if not np.isnan(nodata_output):
                 ds[var].attrs["_FillValue"] = nodata_output
+            ds[var].attrs["long_name"] = var
 
         return ds

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -341,6 +341,10 @@ class DatasetFeatures(DataArrayFeatures):
         )
         var_dim = result.dims[self.feature_dim]
         ds = result.to_dataset(dim=var_dim, promote_attrs=True)
+
+        # Drop variable-level attrs
+        ds.attrs.pop("_FillValue", None)
+
         for var in ds.data_vars:
             ds[var].attrs = self._get_attrs(
                 ds[var].attrs,

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -108,8 +108,9 @@ class FeatureArray(Generic[FeatureArrayType], ABC):
             exclude_dims=set((self.feature_dim_name,)),
             output_core_dims=output_dims,
             output_dtypes=output_dtypes,
-            # Always keep_attrs here to avoid dropping coordinate atttrs. Unwanted attrs
-            # will be dropped during postprocessing.
+            # Keep all attributes here to avoid dropping the spatial reference from the
+            # coordinate attributes. Unwanted attrs will be dropped during
+            # postprocessing.
             keep_attrs=True,
             dask_gufunc_kwargs=dict(
                 output_sizes=output_sizes,

--- a/src/sklearn_raster/utils/estimator.py
+++ b/src/sklearn_raster/utils/estimator.py
@@ -23,6 +23,7 @@ def suppress_feature_name_warnings(func):
     """Suppress warnings related to missing feature names in a wrapped function."""
     msg = "X does not have valid feature names"
 
+    @wraps(func)
     def wrapper(*args, **kwargs):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=msg)

--- a/tests/feature_utils.py
+++ b/tests/feature_utils.py
@@ -160,13 +160,20 @@ def parametrize_model_data(
     y=None,
     feature_array_types=(np.ndarray, xr.DataArray, xr.Dataset),
     mode: Literal["regression", "classification"] = "regression",
+    n_features: int = 5,
+    n_targets: int = 3,
+    n_rows: int = 10,
 ):
     """Parametrize over multiple feature types with the same test data."""
     n_features = (
-        X_image.shape[0] if X_image is not None else X.shape[-1] if X is not None else 5
+        X_image.shape[0]
+        if X_image is not None
+        else X.shape[-1]
+        if X is not None
+        else n_features
     )
-    n_targets = y.shape[-1] if y is not None else 3
-    n_rows = X.shape[0] if X is not None else y.shape[0] if y is not None else 10
+    n_targets = y.shape[-1] if y is not None else n_targets
+    n_rows = X.shape[0] if X is not None else y.shape[0] if y is not None else n_rows
 
     # Default test data
     if X_image is None:


### PR DESCRIPTION
This refines how attrs are tracked in Xarray objects returned by spatial estimators. Specifically:

1. The attrs of the input data are no longer inherited by the output data (except for the coordinate attrs which contain the spatial reference). This avoids retaining attrs that are no longer accurate, e.g. storing the `scale_factor` or `unit` of a feature on a predicted target.
2. New metadata attrs `long_name` and `source_method` are set on the output. `long_name` is part of the CF convention for describing variable names. `source_method` is *not* a standard attr, but I thought it might be useful to track provenance by recording the estimator class and method used to produce the output, e.g. `RandomForestRegressor.predict`. These are in addition to `_FillValue` which we already set.

I also had to make an unrelated change to the CI workflow that lists the test dependency versions in order to track down a bug in an old xarray version.

@grovduck, attrs are something I hadn't put much thought into before, so this is an attempt to clean things up and roughly follow CF conventions, since I think that's what would generally be expected by Xarray users. I've been using [this](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html#attribute-appendix) and [this](https://docs.unidata.ucar.edu/netcdf-c/current/attribute_conventions.html) as references for attributes. 

There are a couple decisions I wasn't sure on that I could use your input:

1. Should we add a `keep_attrs=False` parameter to every estimator method to allow inheriting the input attrs in the output? That's slightly complicated since I think we would still want to override `_FillValue` and `long_name`, but otherwise I think the only downside is having to document another parameter.
2. I'm storing the wrapped method name in a custom attr `source_method`, but we *could* store it in `comment` or `history`, which are standard attrs that seem to generally fit this usage. I think the downside to using those is 1) users are more likely to want to edit them and 2) if we add a `keep_attrs` parameter we probably need to append to them rather than replacing them as they may already exist. The upside of course is that they're already well-defined and should be recognizable.

Any feedback appreciated!