### PR TITLE
Set SWO ecoplot dataset global and variable attributes

### DIFF
--- a/src/sklearn_raster/datasets/_base.py
+++ b/src/sklearn_raster/datasets/_base.py
@@ -193,29 +193,33 @@ def load_swo_ecoplot(
     """
     X, y = sknnr.datasets.load_swo_ecoplot(return_X_y=True, as_frame=True)
     variables = [
-        _VariableMeta("ANNPRE", "Annual precipitation", "ln mm"),
-        _VariableMeta("ANNTMP", "Mean annual temperature", "C"),
-        _VariableMeta("AUGMAXT", "Mean August maximum temperature", "C"),
+        _VariableMeta("ANNPRE", "Annual precipitation", "ln millimeter"),
+        _VariableMeta("ANNTMP", "Mean annual temperature", "degC"),
+        _VariableMeta("AUGMAXT", "Mean August maximum temperature", "degC"),
         _VariableMeta(
-            "CONTPRE", "Percentage of annual precipitation falling in June-August", "%"
+            "CONTPRE",
+            "Percentage of annual precipitation falling in June-August",
+            "percent",
         ),
         _VariableMeta(
             "CVPRE",
             "Coefficient of variation of mean monthly precipitation of December and "
             "July",
         ),
-        _VariableMeta("DECMINT", "Mean December minimum temperature", "C"),
+        _VariableMeta("DECMINT", "Mean December minimum temperature", "degC"),
         _VariableMeta(
             "DIFTMP",
             "Difference between mean August maximum and December minimum temperatures",
-            "C",
+            "degC",
         ),
-        _VariableMeta("SMRTMP", "Mean temperature from May-September", "C"),
-        _VariableMeta("SMRTP", "Growing season moisture stress", "C / ln mm"),
+        _VariableMeta("SMRTMP", "Mean temperature from May-September", "degC"),
+        _VariableMeta(
+            "SMRTP", "Growing season moisture stress", "degC / ln millimeter"
+        ),
         _VariableMeta("ASPTR", "Cosine transformation of aspect"),
-        _VariableMeta("DEM", "Elevation", "m"),
-        _VariableMeta("PRR", "Potential relative radiation", "%"),
-        _VariableMeta("SLPPCT", "Slope", "%"),
+        _VariableMeta("DEM", "Elevation", "meter"),
+        _VariableMeta("PRR", "Potential relative radiation"),
+        _VariableMeta("SLPPCT", "Slope", "percent"),
         _VariableMeta(
             "TPI450", "Topographic position index within a 300m to 450m annulus window"
         ),

--- a/src/sklearn_raster/datasets/_base.py
+++ b/src/sklearn_raster/datasets/_base.py
@@ -50,6 +50,7 @@ class _VariableMeta:
     fill_value: float | None = None
     scale_factor: float | None = None
     add_offset: float | None = None
+    source: str | None = None
 
     @property
     def attrs(self) -> dict[str, Any]:
@@ -60,6 +61,7 @@ class _VariableMeta:
             "_FillValue": self.fill_value,
             "scale_factor": self.scale_factor,
             "add_offset": self.add_offset,
+            "source": self.source,
         }
         return {k: v for k, v in attrs.items() if v is not None}
 
@@ -193,40 +195,114 @@ def load_swo_ecoplot(
     """
     X, y = sknnr.datasets.load_swo_ecoplot(return_X_y=True, as_frame=True)
     variables = [
-        _VariableMeta("ANNPRE", "Annual precipitation", "ln millimeter"),
-        _VariableMeta("ANNTMP", "Mean annual temperature", "degC"),
-        _VariableMeta("AUGMAXT", "Mean August maximum temperature", "degC"),
+        _VariableMeta(
+            "ANNPRE",
+            "Annual precipitation",
+            unit="ln millimeter",
+            scale_factor=0.01,
+            source="PRISM Climate Group, Oregon State University",
+        ),
+        _VariableMeta(
+            "ANNTMP",
+            "Mean annual temperature",
+            unit="degC",
+            scale_factor=0.01,
+            source="PRISM Climate Group, Oregon State University",
+        ),
+        _VariableMeta(
+            "AUGMAXT",
+            "Mean August maximum temperature",
+            unit="degC",
+            scale_factor=0.01,
+            source="PRISM Climate Group, Oregon State University",
+        ),
         _VariableMeta(
             "CONTPRE",
             "Percentage of annual precipitation falling in June-August",
             "percent",
+            scale_factor=0.01,
+            source="PRISM Climate Group, Oregon State University",
         ),
         _VariableMeta(
             "CVPRE",
             "Coefficient of variation of mean monthly precipitation of December and "
             "July",
+            scale_factor=0.01,
+            source="PRISM Climate Group, Oregon State University",
         ),
-        _VariableMeta("DECMINT", "Mean December minimum temperature", "degC"),
+        _VariableMeta(
+            "DECMINT",
+            "Mean December minimum temperature",
+            unit="degC",
+            scale_factor=0.01,
+            source="PRISM Climate Group, Oregon State University",
+        ),
         _VariableMeta(
             "DIFTMP",
             "Difference between mean August maximum and December minimum temperatures",
-            "degC",
+            unit="degC",
+            scale_factor=0.01,
+            source="PRISM Climate Group, Oregon State University",
         ),
-        _VariableMeta("SMRTMP", "Mean temperature from May-September", "degC"),
         _VariableMeta(
-            "SMRTP", "Growing season moisture stress", "degC / ln millimeter"
+            "SMRTMP",
+            "Mean temperature from May-September",
+            unit="degC",
+            scale_factor=0.01,
+            source="PRISM Climate Group, Oregon State University",
         ),
-        _VariableMeta("ASPTR", "Cosine transformation of aspect"),
-        _VariableMeta("DEM", "Elevation", "meter"),
-        _VariableMeta("PRR", "Potential relative radiation"),
-        _VariableMeta("SLPPCT", "Slope", "percent"),
         _VariableMeta(
-            "TPI450", "Topographic position index within a 300m to 450m annulus window"
+            "SMRTP",
+            "Growing season moisture stress",
+            unit="degC / ln millimeter",
+            scale_factor=0.01,
+            source="PRISM Climate Group, Oregon State University",
         ),
-        _VariableMeta("TC1", "Tasseled cap component 1 (brightness)"),
-        _VariableMeta("TC2", "Tasseled cap component 2 (greenness)"),
-        _VariableMeta("TC3", "Tasseled cap component 3 (wetness)"),
-        _VariableMeta("NBR", "Normalized burn ratio"),
+        _VariableMeta(
+            "ASPTR",
+            "Cosine transformation of aspect",
+            scale_factor=0.01,
+            source="Derived by LEMMA from data from USGS Seamless Data Warehouse",
+        ),
+        _VariableMeta(
+            "DEM", "Elevation", unit="meter", source="USGS Seamless Data Warehouse"
+        ),
+        _VariableMeta(
+            "PRR",
+            "Potential relative radiation",
+            source="Derived by LEMMA from data from USGS Seamless Data Warehouse",
+        ),
+        _VariableMeta(
+            "SLPPCT",
+            "Slope",
+            unit="percent",
+            source="Derived by LEMMA from data from USGS Seamless Data Warehouse",
+        ),
+        _VariableMeta(
+            "TPI450",
+            "Topographic position index within a 300m to 450m annulus window",
+            source="Derived by LEMMA from data from USGS Seamless Data Warehouse",
+        ),
+        _VariableMeta(
+            "TC1",
+            "Tasseled cap component 1 (brightness)",
+            source="Landsat imagery temporally fit using the CCDC algorithm",
+        ),
+        _VariableMeta(
+            "TC2",
+            "Tasseled cap component 2 (greenness)",
+            source="Landsat imagery temporally fit using the CCDC algorithm",
+        ),
+        _VariableMeta(
+            "TC3",
+            "Tasseled cap component 3 (wetness)",
+            source="Landsat imagery temporally fit using the CCDC algorithm",
+        ),
+        _VariableMeta(
+            "NBR",
+            "Normalized burn ratio",
+            source="Landsat imagery temporally fit using the CCDC algorithm",
+        ),
     ]
 
     if large_rasters:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -68,6 +68,7 @@ def test_load_dataset(configuration: DatasetConfiguration, as_dataset: bool):
         for var in X_image.data_vars.values():
             assert "_FillValue" in var.attrs
             assert "long_name" in var.attrs
+            assert "source" in var.attrs
 
         # Some Dask schedulers require pickling, so ensure that the loaded dataset is
         # pickleable during compute. We could try computing directly, but that is much

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -61,6 +61,14 @@ def test_load_dataset(configuration: DatasetConfiguration, as_dataset: bool):
     assert y.shape == (configuration.n_samples, configuration.n_targets)
 
     if as_dataset:
+        # All datasets should contain global and variable attrs
+        assert "title" in X_image.attrs
+        assert "comment" in X_image.attrs
+        assert "_FillValue" not in X_image.attrs, "_FillValue should not be global"
+        for var in X_image.data_vars.values():
+            assert "_FillValue" in var.attrs
+            assert "long_name" in var.attrs
+
         # Some Dask schedulers require pickling, so ensure that the loaded dataset is
         # pickleable during compute. We could try computing directly, but that is much
         # slower.


### PR DESCRIPTION
This is an effort to include CF-compliant attributes in the SWO ecoplot example rasters when loaded as an `xr.Dataset`. Previously, the only attributes were those automatically assigned by `rioxarray`. 

@grovduck, I made an attempt to fill out attributes based on the docstring and a [supplementary table](https://figshare.com/articles/dataset/Data_Sheet_1_Mapping_with_height_and_spectral_remote_sensing_implies_that_environment_and_forest_structure_jointly_constrain_tree_community_composition_in_temperate_coniferous_forests_of_eastern_Washington_United_States_docx/21600438/1?file=38283090) from your 2022 Eastern Washington paper, but since I'm just copy/pasting your work, I'm hoping you can double-check and fix anything I got wrong.

I also had a few specific questions that I wasn't sure on:

1. Are any of the bands scaled/offset? This would just be for metadata purposes, since they obviously already match the features in the dataframe.
1. I copied the references from the docstring. Are there more/different sources we should consider citing specifically for the raster data, e.g. the Eastern WA paper?
1. Are there any other attributes that you think we should include?

Diving so deep into the attributes for an example dataset is probably overkill, but I figured it might be helpful for regression testing to have a realistic, complete dataset to work with.