### PR TITLE
Simplify NoData inference

### DIFF
--- a/src/sklearn_raster/ufunc.py
+++ b/src/sklearn_raster/ufunc.py
@@ -24,7 +24,7 @@ class UfuncSampleProcessor:
 
     feature_dim = -1
 
-    def __init__(self, samples: NDArray, *, nodata_input: list[float] | None = None):
+    def __init__(self, samples: NDArray, *, nodata_input: NDArray):
         self.samples = samples
         self.nodata_input = nodata_input
 
@@ -38,7 +38,8 @@ class UfuncSampleProcessor:
 
     def _get_nodata_mask(self) -> NDArray | None:
         # Skip allocating a mask if the array is not float and NoData wasn't given
-        if not self._input_supports_nan and self.nodata_input is None:
+        nodata_specified = np.any([n is not None for n in self.nodata_input])
+        if not self._input_supports_nan and not nodata_specified:
             return None
 
         mask = np.zeros(self.samples.shape, dtype=bool)
@@ -48,7 +49,7 @@ class UfuncSampleProcessor:
             mask |= np.isnan(self.samples)
 
         # If NoData was specified, mask those values
-        if self.nodata_input is not None:
+        if nodata_specified:
             mask |= self.samples == self.nodata_input
 
         # Return a mask where any feature contains NoData

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -375,14 +375,6 @@ def test_nan_filled(feature_array_type: type[FeatureArrayType], nan_fill: float 
     unwrap_features(result)
 
 
-def test_skip_nodata_mask_if_unneeded():
-    """If features are not float and nodata isn't specified, there should be no mask."""
-    a = np.ones((3, 2, 2), dtype=int)
-    features = FeatureArray.from_feature_array(a, nodata_input=None)
-
-    assert features.nodata_input is None
-
-
 @pytest.mark.parametrize("nodata_input", ["test", {}, False], ids=type)
 def test_nodata_validates_type(nodata_input):
     """Test that invalid NoData types are recognized."""
@@ -467,28 +459,6 @@ def test_nodata_dataset_some_fillvalues(nodata_input, fill_vals):
     # Nodata vals should match the fill values, even if some are None
     else:
         assert features.nodata_input.tolist() == fill_vals
-
-
-@pytest.mark.parametrize(
-    "nodata_input", [None, -32768], ids=["without_nodata", "with_nodata"]
-)
-def test_nodata_dataset_global_fillvalue(nodata_input):
-    """Test that a global _FillValue is broadcast if per-feature don't exist."""
-    n_features = 3
-    global_fill_val = 42
-    das = [
-        xr.DataArray(np.ones((n_features, 2, 2))).rename(i) for i in range(n_features)
-    ]
-
-    ds = xr.merge(das).assign_attrs({"_FillValue": global_fill_val})
-    features = FeatureArray.from_feature_array(ds, nodata_input=nodata_input)
-
-    # _FillValue should be ignored if nodata_input is provided
-    if nodata_input is not None:
-        assert features.nodata_input.tolist() == [nodata_input] * n_features
-    # The global fill value should be used when per-feature fill values are unavailable
-    else:
-        assert features.nodata_input.tolist() == [global_fill_val] * n_features
 
 
 @pytest.mark.parametrize("nodata_output", [np.nan, 0, -32768])


### PR DESCRIPTION
This slightly simplifies how a missing `nodata_input` parameter is inferred from `_FillValue` attributes, based on [discussion](https://github.com/lemma-osu/sklearn-raster/pull/68#discussion_r2198937216) in #68.

Previously, a global `_FillValue`, i.e. a top-level attribute of an `xr.Dataset`, would be applied to variables *if* they did not define their own `_FillValue`. To simplify inference rules and be more consistent with CF conventions, the global attribute is now ignored; NoData is only inferred from variable-level attributes. In practice, this means there are two cases where `_FillValue` is applied as NoData (assuming `nodata_input` was not provided by the user):

- In an `xr.Dataset`, the `_FillValue` set on each variable will be assigned to that feature.
- In an `xr.DataArray`, the `_FillValue` set on the array will be assigned to all features.

When a `_FillValue` attribute is missing, the inferred value will be `None`, which represents that the feature does not contain NoData. Internally, a `FeatureArray` with no defined NoData values will now store an array of all `None` values, rather than storing `None` directly, in order to slightly simplify implementation and typing.

Finally, I removed two tests that no longer applied after the changes above.

@grovduck, the original rules weren't as convoluted as I remembered, but I still think it's worth getting rid of the conditional usage of the global `_FillValue` since it's a bit confusing and inconsistent with conventions. Hopefully the docs can be rewritten more clearly now that there are only two cases where NoData is inferred.