### PR TITLE
Remove `dask` extra dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+
+- Dask `diagnostics` and `dataframe` extras are no longer required dependencies
+
 ## [0.1.0.dev0] - 2025-07-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 keywords = []
 dependencies = [
     "numpy",
-    "dask[diagnostics,dataframe]",
+    "dask",
     "scikit-learn",
     "typing-extensions",
 ]
@@ -69,6 +69,7 @@ dependencies = [
 [tool.hatch.envs.tutorials]
 dependencies = [
     "sklearn-raster[tutorials]",
+    "dask[diagnostics,distributed]",
 ]
 
 [tool.hatch.envs.test.scripts]


### PR DESCRIPTION
Closes #71 by removing `diagnostics` and `dataframe` dask extras from the required dependencies. I added `diagnostics` and `distributed` into the Hatch `tutorials` environment instead since they're helpful for development when testing local clusters. They might end up being used in `sklearn-raster[tutorials]` later, but I don't think it's worth putting them there pre-emptively.