### PR TITLE
Document related packages

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
     - Compatible Estimators: guide/compatible_estimators.md
     - Raster Formats: guide/raster_formats.md
     - Metadata: guide/metadata.md
+    - Related Packages: guide/related_packages.md
   - API Reference:
     - Wrapping Estimators: api/wrap.md
     - Datasets:

--- a/docs/pages/guide/getting_started.md
+++ b/docs/pages/guide/getting_started.md
@@ -26,6 +26,7 @@ The user guide contains more information about specific topics like:
 - Which [estimators are compatible](compatible_estimators.md) with `sklearn-raster`
 - Supported [raster formats](raster_formats.md) and their pros and cons
 - How [metadata](metadata.md) like spatial references, band names, and NoData masks are handled
+- How `sklearn-raster` compares to [related packages](related_packages.md) like `sklearn-xarray`, `dask-ml`, and `scikit-map`.
 
 ### Tutorials
 

--- a/docs/pages/guide/related_packages.md
+++ b/docs/pages/guide/related_packages.md
@@ -1,0 +1,21 @@
+There are a number of other packages that combine Scikit-Learn with Xarray and/or use estimators for mapping. The table below attempts to compare their features (to the best of our understanding) with `sklearn-raster` so you can choose the right tool for your application.
+
+<style>
+/* Highlight the sklearn-raster header */
+table tr > th:nth-child(2) {
+  border: 2px dotted var(--md-typeset-a-color);
+}
+</style>
+
+| Supported features | [sklearn-raster](https://sklearn-raster.readthedocs.io/en/latest/) | [sklearn-xarray](https://phausamann.github.io/sklearn-xarray/) | [dask-ml](https://ml.dask.org/) | [scikit-map](https://github.com/openlandmap/scikit-map) | [pyimpute](https://github.com/perrygeo/pyimpute) | [pyspatialml](https://stevenpawley.github.io/Pyspatialml/) |
+|:---|:---:|:---:|:---:|:---:|:---:|:---:|
+| 2D prediction | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| 3D prediction | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| n-D prediction  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Preserve NoData and spatial refs. | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Parallel prediction | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| Lazy prediction | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Xarray support | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Parallel fitting | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Custom estimators | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Raster processing tools | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |

--- a/docs/pages/guide/related_packages.md
+++ b/docs/pages/guide/related_packages.md
@@ -1,4 +1,6 @@
-There are a number of other packages that combine Scikit-Learn with Xarray and/or use estimators for mapping. The table below attempts to compare their features (to the best of our understanding) with `sklearn-raster` so you can choose the right tool for your application.
+There are a number of other packages that combine Scikit-Learn with Xarray and/or use estimators for mapping. The table below attempts to compare their features (to the best of our understanding) with `sklearn-raster` so you can choose the right tool for your application. 
+
+*Supported features are described in detail [below](#supported-features).*
 
 <style>
 /* Highlight the sklearn-raster header */
@@ -7,15 +9,32 @@ table tr > th:nth-child(2) {
 }
 </style>
 
-| Supported features | [sklearn-raster](https://sklearn-raster.readthedocs.io/en/latest/) | [sklearn-xarray](https://phausamann.github.io/sklearn-xarray/) | [dask-ml](https://ml.dask.org/) | [scikit-map](https://github.com/openlandmap/scikit-map) | [pyimpute](https://github.com/perrygeo/pyimpute) | [pyspatialml](https://stevenpawley.github.io/Pyspatialml/) |
+| [Supported features](#supported-features) | [sklearn-raster](https://sklearn-raster.readthedocs.io/en/latest/) | [sklearn-xarray](https://phausamann.github.io/sklearn-xarray/) | [dask-ml](https://ml.dask.org/) | [scikit-map](https://github.com/openlandmap/scikit-map) | [pyimpute](https://github.com/perrygeo/pyimpute) | [pyspatialml](https://stevenpawley.github.io/Pyspatialml/) |
 |:---|:---:|:---:|:---:|:---:|:---:|:---:|
-| 2D prediction | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| 3D prediction | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| n-D prediction  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Preserve NoData and spatial refs. | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Parallel prediction | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| Lazy prediction | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| 2D outputs | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| 3D outputs | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| n-D outputs  | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Preserves metadata | ✅ | ❌ | ❌ | ✅[^on-disk] | ✅[^on-disk] | ✅[^on-disk] |
+| Parallel computation | ✅ | ✅[^wrapper] | ✅ | ✅ | ❌ | ❌ |
+| Lazy computation | ✅ | ✅[^deferred] | ✅ | ❌ | ❌ | ❌ |
 | Xarray support | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | Parallel fitting | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | Custom estimators | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | Raster processing tools | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+
+### Supported Features
+
+- **2D outputs**: Package is capable of generating 2D model outputs from 2D feature inputs, e.g. predicting georeferenced land cover maps or transforming geospatial imagery.
+- **3D outputs**: Package is capable of generating 3D model outputs from 3D feature inputs, e.g. predicting a time series of georeferenced maps.
+- **n-D outputs**: Package is capable of generating model outputs with arbitrary dimensionality from n-D feature inputs, e.g. predicting a time series of climate variables at various pressure levels.
+- **Preserves metadata**: Model outputs retain the metadata of the input data, such as spatial references, band names, and NoData masks.
+- **Parallel computation**: Package computes model outputs in parallel.
+- **Lazy computation**: Package computes model outputs lazily, deferring computation until necessary.
+- **Xarray support**: Package supports Xarray data structures as model inputs and outputs.
+- **Parallel fitting**: Package supports fitting estimators in parallel to reduce training time.
+- **Custom estimators**: Package implements additional estimators.
+- **Raster processing tools**: Package includes additional functionality for processing raster data beyond ML modeling.
+
+[^on-disk]: `scikit-map`, `pyimpute`, and `pyspatialml` only preserve metadata when writing outputs directly to disk.
+[^wrapper]: `sklearn-xarray` supports parallel operations by [wrapping `dask-ml` estimators](https://phausamann.github.io/sklearn-xarray/content/wrappers.html#wrapping-dask-ml-estimators).
+[^deferred]: `sklearn-xarray` [supports lazy evaluation](https://phausamann.github.io/sklearn-xarray/content/target.html#lazy-evaluation) by deferring computation, but requires that the entire dataset is loaded into memory.


### PR DESCRIPTION
Closes #37 by adding a documentation page that compares the features of `sklearn-raster` with other related packages. I tried to be impartial while focusing on features that would be generally relevant in a raster mapping context that `sklearn-raster` is designed to fill. My understanding of most of the other packages is based on a pretty shallow reading of their documentation and/or source code, so it's not impossible that I missed some supported features.

@grovduck, any feedback is welcome here! Let me know if you can think of other features to highlight or if anything needs clarification.