### PR TITLE
Add support for `pd.DataFrame` features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - HTML reprs for `FeatureArrayEstimator` in a Jupyter notebook.
 - The estimator wrapped by `FeatureArrayEstimator` is exposed with the `wrapped_estimator` attribute.
+- Added support for applying wrapped estimator methods to `pd.DataFrame` feature arrays.
 
 ### Changed
 

--- a/docs/pages/guide/raster_formats.md
+++ b/docs/pages/guide/raster_formats.md
@@ -1,4 +1,6 @@
-`sklearn-raster` supports applying estimator methods to rasters stored in a variety of formats, referred to collectively as **feature arrays**. Numpy arrays can be used for small rasters that fit easily in memory, while Xarray `Dataset` and `DataArray` are ideal for large datasets that benefit from deferred, parallel computation. Estimator methods will return data in the same format that it is provided, e.g. predictions generated from an Xarray `xr.Dataset` will be stored in an `xr.Dataset`. All feature arrays support [arbitrary dimensionality](#dimensionality).
+`sklearn-raster` supports applying estimator methods to rasters stored in a variety of formats, referred to collectively as **feature arrays**. Numpy arrays can be used for small rasters that fit easily in memory, while Xarray `Dataset` and `DataArray` are ideal for large datasets that benefit from deferred, parallel computation. Pandas dataframes can be used for extracted tabular data. 
+
+Estimator methods will return data in the same format that it is provided, e.g. predictions generated from an Xarray `xr.Dataset` will be stored in an `xr.Dataset`. Most feature arrays support [arbitrary dimensionality](#dimensionality).
 
 ## Raster Formats
 
@@ -74,6 +76,13 @@ print(pred.data_vars) # ['land_cover']
 print(pred.land_cover.shape) # (128, 128)
 ```
 
+### Pandas DataFrame
+
+While dataframes are not a conventional raster format, they can be used for applications like storing extracted pixel values in a tabular format of shape `(samples, band)`. In that context, a `FeatureArrayEstimator` provides some convenient features over an unmodified `sklearn` estimator when predicting or transforming dataframes:
+
+1. Methods return dataframe outputs that preserve the index and target names as columns.
+2. Samples with masked values in the input data can be skipped and encoded in the output dataframe.
+
 ### Format Summary
 
 | <div style="width: 100px;">Raster format</div> | Arbitrary dimensionality | Parallel operations | Lazy evaluation | Larger-than-memory | Metadata attributes | Mixed variable types |
@@ -81,6 +90,7 @@ print(pred.land_cover.shape) # (128, 128)
 | `np.ndarray` | ✅ |❌ | ❌ | ❌ | ❌ | ❌ |
 | `xr.DataArray` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | `xr.Dataset` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `pd.DataFrame` | ❌ |❌ | ❌ | ❌ | ❌ | ✅ |
 
 ## Dimensionality
 

--- a/docs/pages/guide/raster_formats.md
+++ b/docs/pages/guide/raster_formats.md
@@ -85,12 +85,12 @@ While dataframes are not a conventional raster format, they can be used for appl
 
 ### Format Summary
 
-| <div style="width: 100px;">Raster format</div> | Arbitrary dimensionality | Parallel operations | Lazy evaluation | Larger-than-memory | Metadata attributes | Mixed variable types |
-|:-------------:|--------------------------|---------------------|-----------------|--------------------|---------------------|----------------------|
-| `np.ndarray` | ✅ |❌ | ❌ | ❌ | ❌ | ❌ |
-| `xr.DataArray` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `xr.Dataset` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅[^mixed-types] |
-| `pd.DataFrame` | ❌ |❌ | ❌ | ❌ | ❌ | ✅[^mixed-types] |
+| <div style="width: 100px;">Raster format</div> | Arbitrary dimensionality | Parallel operations | Lazy evaluation | Larger-than-memory | Metadata attributes |
+|:-------------:|--------------------------|---------------------|-----------------|--------------------|---------------------|
+| `np.ndarray` | ✅ |❌ | ❌ | ❌ | ❌ |
+| `xr.DataArray` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `xr.Dataset` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `pd.DataFrame` | ❌ |❌ | ❌ | ❌ | ❌ |
 
 ## Dimensionality
 

--- a/docs/pages/guide/raster_formats.md
+++ b/docs/pages/guide/raster_formats.md
@@ -55,7 +55,7 @@ print(pred["target"].values) # ['land_cover']
 
 ### Xarray Dataset
 
-An `xr.Dataset` in the shape `(y, x)` with bands stored as variables can also be used with `sklearn-raster` estimators. It offers similar benefits to `xr.DataArray`, with the added ability to mix data types and NoData values across bands. 
+An `xr.Dataset` in the shape `(y, x)` with bands stored as variables can also be used with `sklearn-raster` estimators. It offers similar benefits to `xr.DataArray`, with the added ability to mix data types[^mixed-types] and NoData values across bands. 
 
 Load a `Dataset` from a GeoTIFF file using `rioxarray`:
 
@@ -89,11 +89,13 @@ While dataframes are not a conventional raster format, they can be used for appl
 |:-------------:|--------------------------|---------------------|-----------------|--------------------|---------------------|----------------------|
 | `np.ndarray` | ✅ |❌ | ❌ | ❌ | ❌ | ❌ |
 | `xr.DataArray` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `xr.Dataset` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `pd.DataFrame` | ❌ |❌ | ❌ | ❌ | ❌ | ✅ |
+| `xr.Dataset` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅[^mixed-types] |
+| `pd.DataFrame` | ❌ |❌ | ❌ | ❌ | ❌ | ✅[^mixed-types] |
 
 ## Dimensionality
 
 While the examples above focus on simple spatial rasters with `x` and `y` dimensions, `sklearn-raster` supports arbitrary input and output dimensionality. For example, generating predictions from a time series of climate data at various pressure levels of shape `(variable, time, z, y, x)` would return an output of shape `(target, time, z, y, x)`. Operations are broadcast by implicitly flattening all non-feature dimensions.
 
 [^bands]: `(band, y, x)` is the common shape for 2D geospatial raster data, but any shape is supported as long as the first dimension corresponds with the feature columns of the training dataset.
+
+[^mixed-types]: Data are implicitly converted to `xr.DataArray` when applying estimator methods, which causes mixed data types to be promoted to the maximum data type.

--- a/src/sklearn_raster/types.py
+++ b/src/sklearn_raster/types.py
@@ -4,13 +4,16 @@ import enum
 from collections.abc import Sequence
 from typing import Callable, Union
 
+import pandas as pd
 import xarray as xr
 from numpy.typing import NDArray
 from sklearn.base import BaseEstimator
 from typing_extensions import Any, Concatenate, ParamSpec, TypeVar
 
 DaskBackedType = TypeVar("DaskBackedType", xr.DataArray, xr.Dataset)
-FeatureArrayType = TypeVar("FeatureArrayType", NDArray, xr.DataArray, xr.Dataset)
+FeatureArrayType = TypeVar(
+    "FeatureArrayType", NDArray, xr.DataArray, xr.Dataset, pd.DataFrame
+)
 EstimatorType = TypeVar("EstimatorType", bound=BaseEstimator)
 AnyType = TypeVar("AnyType", bound=Any)
 NoDataType = Union[float, Sequence[float], None]


### PR DESCRIPTION
This adds `pd.DataFrame` as a supported feature array type, allowing estimators to predict, transform, etc. to and from dataframes. Under the hood, this is done by converting the dataframe to a 2D `xr.DataArray` (features and rows), applying the ufunc as normal, and converting it back to a dataframe. 

Unlike higher-dimensional data types, dataframes are already technically supported with `sklearn` estimators, but using a wrapped estimator offers some advantages:

1. Dataframe inputs produce dataframe outputs with a matching index and targets as column names.
2. Rows that contain NaN or encoded NoData features can be 1) skipped for performance and 2) encoded as NoData in the output.

The other immediate benefit is that if you wrap a `FeatureArrayEstimator` to work with other data types, it now works with dataframes as well without needing to access the underlying estimator. 
 
Currently this is explicitly tied to Pandas dataframes and doesn't support any other duck-typed dataframes. There's some discussion in pydata/xarray#10135 about a more generic dataframe interface for Xarray which we might consider switching to if and when that happens.