### PR TITLE
Explicitly set default merge `compat` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix deprecation warning for `xarray>=2025.08.0` by explicitly setting `compat` mode
+
 ### Added
 
 - HTML reprs for `FeatureArrayEstimator` in a Jupyter notebook.

--- a/src/sklearn_raster/datasets/_base.py
+++ b/src/sklearn_raster/datasets/_base.py
@@ -83,7 +83,7 @@ def _load_rasters_to_dataset(
             .assign_attrs(var_meta.attrs)
         )
         das.append(da)
-    ds = xr.merge(das, combine_attrs="drop_conflicts")
+    ds = xr.merge(das, compat="no_conflicts", combine_attrs="drop_conflicts")
     ds.attrs = global_attrs if global_attrs is not None else {}
     return ds
 


### PR DESCRIPTION
This fixes a deprecation warning introduced in `xarray==2025.08.0` due to the default `compat` mode changing from "no_conflicts" to "override" in a future release. We should never have duplicate variables when loading rasters, so this maintains the current behavior which is a more strict check for conflicting values.

(I ran the full test matrix locally since CI is still out of commission.)