### PR TITLE
Require `xarray` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix `xarray` being incorrectly listed as an optional dependency
 - Fix deprecation warning for `xarray>=2025.08.0` by explicitly setting `compat` mode
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 keywords = []
 dependencies = [
     "numpy",
+    "xarray",
     "dask",
     "scikit-learn",
     "typing-extensions",
@@ -23,7 +24,6 @@ dependencies = [
 [project.optional-dependencies]
 datasets = [
     "sknnr",
-    "xarray",
     "rioxarray", 
     "rasterio", 
     "pooch",


### PR DESCRIPTION
Closes #80 by correctly listing `xarray` as required instead of optional.