### PR TITLE
Tranpose ufunc parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `ufunc.FeaturewiseUfunc` was added for ufuncs that operate on a feature core input dimension with NoData handling. This replaces `FeatureArray.apply_ufunc_across_features` and adds support for ufuncs with multiple feature array inputs.
+- `ufunc.Dimension` and `ufunc.Output` were added for defining a `FeaturewiseUfunc` based on its expected outputs. This transposes the parameters used in the previous API and adds support for inferring dimension size from coordinates and default NoData values from data type.
 
 ### Removed
 
 - `FeatureArray.apply_ufunc_across_features` has been removed in favor of `ufunc.FeaturewiseUfunc`
+- `utils.decorators.map_over_arguments` was removed with no public replacement.
 - Dropped support for Python `3.9` and `3.10`
 - Removed dependency on `typing-extensions`
 

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -8,7 +8,7 @@ from sklearn.base import BaseEstimator, clone
 
 from .features import FeatureArray
 from .types import EstimatorType, MissingType
-from .ufunc import FeaturewiseUfunc
+from .ufunc import Dimension, FeaturewiseUfunc, Output
 from .utils.decorators import (
     requires_attributes,
     requires_fitted,
@@ -194,25 +194,25 @@ class FeatureArrayEstimator(Generic[EstimatorType], BaseEstimator):
             The predicted values. Array types will be in the shape (targets, ...) while
             xr.Dataset will store targets as variables.
         """
-        output_dim_name = "target"
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
-
         self._check_feature_names(features.feature_names)
 
         # Any estimator with an undefined type should fall back to floating
         # point for safety.
         estimator_type = getattr(self.wrapped_estimator, "_estimator_type", "")
         output_dtype = ESTIMATOR_OUTPUT_DTYPES.get(estimator_type, np.float64)
-        output_names = self.target_names_in_ or generate_sequential_names(
-            self.n_targets_in_, output_dim_name
-        )
 
         ufunc = FeaturewiseUfunc(
             suppress_feature_name_warnings(self.wrapped_estimator.predict),
-            output_dims=[[output_dim_name]],
-            output_dtypes=[output_dtype],
-            output_sizes={output_dim_name: self.n_targets_in_},
-            output_coords=[{output_dim_name: output_names}],
+            outputs=[
+                Output.from_1d(
+                    name="target",
+                    size=self.n_targets_in_,
+                    coords=self.target_names_in_
+                    or generate_sequential_names(self.n_targets_in_, "target"),
+                    dtype=output_dtype,
+                )
+            ],
         )
         return ufunc(
             features,
@@ -308,9 +308,7 @@ class FeatureArrayEstimator(Generic[EstimatorType], BaseEstimator):
             The predicted class probabilities. Array types will be in the shape
             (classes, ...) while xr.Dataset will store classes as variables.
         """
-        output_dim_name = "class"
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
-
         self._check_feature_names(features.feature_names)
 
         if self.n_targets_in_ > 1:
@@ -322,10 +320,14 @@ class FeatureArrayEstimator(Generic[EstimatorType], BaseEstimator):
 
         ufunc = FeaturewiseUfunc(
             suppress_feature_name_warnings(self.wrapped_estimator.predict_proba),
-            output_dims=[[output_dim_name]],
-            output_dtypes=[np.float64],
-            output_sizes={output_dim_name: len(self.wrapped_estimator.classes_)},
-            output_coords=[{output_dim_name: list(self.wrapped_estimator.classes_)}],
+            outputs=[
+                Output.from_1d(
+                    name="class",
+                    size=len(self.wrapped_estimator.classes_),
+                    coords=list(self.wrapped_estimator.classes_),
+                    dtype=np.float64,
+                )
+            ],
         )
         return ufunc(
             features,
@@ -478,29 +480,24 @@ class FeatureArrayEstimator(Generic[EstimatorType], BaseEstimator):
             Array types will be in the shape (neighbor, ...) while xr.Dataset will store
             neighbors as variables.
         """
-        output_dim_name = "neighbor"
-        num_outputs = 2 if return_distance else 1
-
-        if nodata_output is None:
-            nodata_output = (np.nan, -2147483648) if return_distance else -2147483648
-        elif return_distance is False and isinstance(nodata_output, tuple | list):
+        if return_distance is False and isinstance(nodata_output, tuple | list):
             msg = "`nodata_output` must be a scalar when `return_distance` is False."
             raise ValueError(msg)
 
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
+        self._check_feature_names(features.feature_names)
         k = n_neighbors or cast(int, getattr(self.wrapped_estimator, "n_neighbors", 5))
 
-        self._check_feature_names(features.feature_names)
-        neighbor_coords: dict[str, list[str] | list[int]] = {
-            output_dim_name: generate_sequential_names(k, output_dim_name)
-        }
-
+        neighbor_dim = Dimension(
+            name="neighbor", size=k, coords=generate_sequential_names(k, "neighbor")
+        )
+        dist_output_meta = Output(dims=[neighbor_dim], dtype=np.float64)
+        idx_output_meta = Output(dims=[neighbor_dim], dtype=np.int32)
         ufunc = FeaturewiseUfunc(
             suppress_feature_name_warnings(self.wrapped_estimator.kneighbors),
-            output_dims=[[output_dim_name]] * num_outputs,
-            output_dtypes=[float, int] if return_distance else [int],
-            output_sizes={output_dim_name: k},
-            output_coords=[neighbor_coords] * num_outputs,
+            outputs=[dist_output_meta, idx_output_meta]
+            if return_distance
+            else [idx_output_meta],
         )
         return ufunc(
             features,
@@ -601,18 +598,20 @@ class FeatureArrayEstimator(Generic[EstimatorType], BaseEstimator):
             while xr.Dataset will store features as variables, with the feature names
             based on the estimator's `get_feature_names_out` method.
         """
-        output_dim_name = "feature"
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
         feature_names = self.wrapped_estimator.get_feature_names_out()
-
         self._check_feature_names(features.feature_names)
 
         ufunc = FeaturewiseUfunc(
             suppress_feature_name_warnings(self.wrapped_estimator.transform),
-            output_dims=[[output_dim_name]],
-            output_dtypes=[np.float64],
-            output_sizes={output_dim_name: len(feature_names)},
-            output_coords=[{output_dim_name: list(feature_names)}],
+            outputs=[
+                Output.from_1d(
+                    name="feature",
+                    size=len(feature_names),
+                    coords=list(feature_names),
+                    dtype=np.float64,
+                )
+            ],
         )
         return ufunc(
             features,
@@ -708,22 +707,19 @@ class FeatureArrayEstimator(Generic[EstimatorType], BaseEstimator):
             The inverse-transformed features. Array types will be in the shape
             (features, ...) while xr.Dataset will store features as variables.
         """
-        output_dim_name = "feature"
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
-        feature_names = self.feature_names_in_
-
-        # If the estimator was fitted without feature names, use sequential identifiers
-        if not feature_names:
-            feature_names = generate_sequential_names(
-                self.n_features_in_, output_dim_name
-            )
 
         ufunc = FeaturewiseUfunc(
             suppress_feature_name_warnings(self.wrapped_estimator.inverse_transform),
-            output_dims=[[output_dim_name]],
-            output_dtypes=[np.float64],
-            output_sizes={output_dim_name: self.n_features_in_},
-            output_coords=[{output_dim_name: feature_names}],
+            outputs=[
+                Output.from_1d(
+                    name="feature",
+                    size=self.n_features_in_,
+                    coords=self.feature_names_in_
+                    or generate_sequential_names(self.n_features_in_, "feature"),
+                    dtype=np.float64,
+                )
+            ],
         )
         return ufunc(
             features,

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -18,9 +18,6 @@ from .types import (
     NoDataMap,
     NoDataType,
 )
-from .utils.decorators import (
-    map_over_arguments,
-)
 from .utils.features import can_cast_nodata_value
 
 
@@ -166,14 +163,13 @@ class FeatureArray(Generic[FeatureArrayType], ABC):
         return features
 
     @abstractmethod
-    @map_over_arguments("result", "nodata_output", "output_coords")
     def _postprocess_ufunc_output(
         self,
         result: FeatureArrayType,
         *,
         nodata_output: float | int,
         func: Callable,
-        output_coords: dict[str, list[str | int]] | None = None,
+        output_coords: dict[str, list[str | int]],
         keep_attrs: bool = False,
     ) -> FeatureArrayType:
         """
@@ -220,14 +216,13 @@ class NDArrayFeatures(FeatureArray):
         # Copy to avoid mutating the original array
         return np.moveaxis(features.copy(), 0, -1)
 
-    @map_over_arguments("result")
     def _postprocess_ufunc_output(
         self,
         result: NDArray,
         *,
         nodata_output: float | int,
         func: Callable,
-        output_coords=None,
+        output_coords: dict[str, list[str | int]],
         keep_attrs: bool = False,
     ) -> NDArray:
         """Postprocess the output by moving features back to the first dimension."""
@@ -262,19 +257,17 @@ class DataArrayFeatures(FeatureArray):
         global_fill_value = self.feature_array.attrs.get("_FillValue")
         return {name: global_fill_value for name in self.feature_names}
 
-    @map_over_arguments("result", "nodata_output", "output_coords")
     def _postprocess_ufunc_output(
         self,
         result: xr.DataArray,
         *,
         nodata_output: float | int,
         func: Callable,
-        output_coords: dict[str, list[str | int]] | None = None,
+        output_coords: dict[str, list[str | int]],
         keep_attrs: bool = False,
     ) -> xr.DataArray:
         """Process the ufunc output by assigning coordinates and transposing."""
-        if output_coords is not None:
-            result = result.assign_coords(output_coords)
+        result = result.assign_coords(output_coords)
 
         # Transpose features from the last to the first dimension
         result = result.transpose(result.dims[-1], ...)
@@ -360,14 +353,13 @@ class DatasetFeatures(DataArrayFeatures):
             for var in self.dataset.data_vars
         }
 
-    @map_over_arguments("result", "nodata_output", "output_coords")
     def _postprocess_ufunc_output(
         self,
         result: xr.DataArray,
         *,
         nodata_output: float | int,
         func: Callable,
-        output_coords: dict[str, list[str | int]] | None = None,
+        output_coords: dict[str, list[str | int]],
         keep_attrs: bool = False,
     ) -> xr.Dataset:
         """Process the ufunc output converting from DataArray to Dataset."""
@@ -409,14 +401,13 @@ class DataFrameFeatures(DataArrayFeatures):
         data_array = xr.Dataset.from_dataframe(features).to_dataarray()
         super().__init__(data_array, nodata_input=nodata_input)
 
-    @map_over_arguments("result", "nodata_output", "output_coords")
     def _postprocess_ufunc_output(
         self,
         result: xr.DataArray,
         *,
         nodata_output: float | int,
         func: Callable,
-        output_coords: dict[str, list[str | int]] | None = None,
+        output_coords: dict[str, list[str | int]],
         keep_attrs: bool = False,
     ) -> pd.DataFrame:
         """Process the ufunc output converting from DataArray to DataFrame."""

--- a/src/sklearn_raster/ufunc/__init__.py
+++ b/src/sklearn_raster/ufunc/__init__.py
@@ -1,0 +1,4 @@
+from ._base import FeaturewiseUfunc
+from ._meta import Dimension, Output
+
+__all__ = ["Dimension", "Output", "FeaturewiseUfunc"]

--- a/src/sklearn_raster/ufunc/_base.py
+++ b/src/sklearn_raster/ufunc/_base.py
@@ -8,27 +8,23 @@ import numpy.ma as ma
 import xarray as xr
 from numpy.typing import NDArray
 
-from .features import (
-    DataArrayFeatures,
-    DataFrameFeatures,
-    DatasetFeatures,
-    NDArrayFeatures,
-)
-from .types import ArrayUfunc, FeatureArrayType, MaybeTuple
-from .utils.decorators import (
+from ..types import ArrayUfunc, FeatureArrayType, MaybeTuple
+from ..utils.decorators import (
     limit_inner_threads,
-    map_over_arguments,
     with_inputs_reshaped_to_ndim,
 )
-from .utils.features import get_minimum_precise_numeric_dtype
+from ..utils.features import get_minimum_precise_numeric_dtype
+from ..utils.ufunc import _UfuncResult
+from ._meta import _UfuncMeta
 
 if TYPE_CHECKING:
-    from .features import FeatureArray
+    from ..features import FeatureArray
+    from ._meta import Output
 
 
 class _UfuncInput:
     """
-    An array of samples with NoData handling for use in a RasterUfunc.
+    An array of samples with NoData handling for use in a FeaturewiseUfunc.
 
     The processor takes Numpy arrays in the shape (samples, features) and:
 
@@ -85,59 +81,67 @@ class _UfuncInput:
         return self.samples
 
 
+class _UfuncInputs:
+    """A collection of inputs to a FeaturewiseUfunc with NoData handling."""
+
+    def __init__(
+        self, arrays: tuple[NDArray, ...], nodata_inputs: tuple[ma.MaskedArray, ...]
+    ):
+        self.inputs = [
+            _UfuncInput(array, nodata_input=nodata)
+            for array, nodata in zip(arrays, nodata_inputs, strict=True)
+        ]
+
+    def fill_nans(self, nan_fill: float | None) -> None:
+        """Fill NaNs in all input arrays in place."""
+        for uinput in self.inputs:
+            uinput.samples = uinput._fill_nans(nan_fill)
+
+    def get_nodata_mask(self) -> NDArray | None:
+        """Return a mask where any input array contains NoData."""
+        any_masked = bool(sum([array._num_masked for array in self.inputs]))
+        if any_masked:
+            return np.stack(
+                [
+                    uinput.nodata_mask
+                    for uinput in self.inputs
+                    if uinput.nodata_mask is not None
+                ],
+                axis=-1,
+            ).max(axis=-1)
+        return None
+
+    def get_samples(self) -> list[NDArray]:
+        """Return a list of the sample arrays for all inputs."""
+        return [uinput.samples for uinput in self.inputs]
+
+
 class FeaturewiseUfunc:
     """
     Build a feature-wise universal function with NoData filling, skipping, and masking.
-
-    The ufunc is applied with a single core input dimension representing features and
-    returns arbitrary outputs with the number and dimensions defined by `output_dims`.
 
     Parameters
     ----------
     func : callable
         A function to apply to flattened array(s). The function should accept one or
         more arrays of shape (samples, features) and return one or more arrays of shape
-        (samples, size), where size is defined by `output_sizes`.
-    output_dims : list[list[str]]
-        Output core dimension names as a list of lists. The outer list represents the
-        number of return values from `func` and the inner lists represent the output
-        dimensions of each return value. A single value, e.g. [['variable']], represents
-        a single return with a single output dimension named 'variable'.
-    output_dtypes : list[np.dtype], optional
-        The expected output data types for each value returned by `func`. Required for
-        Dask-backed arrays.
-    output_sizes : dict[str, int], optional
-        Mapping from dimension names in `output_dims` to their sizes. Required for Dask-
-        backed arrays.
-    output_coords : list[dict[str, list[str] | list[int]]], optional
-        Custom coordinates to assign by dimension, provided as a list of mappings from
-        dimensions to coordinates per output array. For example, a function that returns
-        a single array with one dimension of three bands could be defined with
-        `output_coords=[{"band": ["R", "G", "B"]}]`.
+        (samples, size) defined by `outputs`.
+    outputs : list[Output]
+        A list of metadata for each output array returned by `func`. The length of the
+        list determines the number of arrays returned by the ufunc, and the metadata
+        defines the dimensions, data types, coordinates, and NoData values of each
+        output array.
     """
 
-    def __init__(
-        self,
-        func: ArrayUfunc,
-        *,
-        output_dims: list[list[str]] | None = None,
-        output_dtypes: list[np.dtype] | None = None,
-        output_sizes: dict[str, int] | None = None,
-        output_coords: list[dict[str, list[str] | list[int]]] | None = None,
-    ):
+    def __init__(self, func: ArrayUfunc, *, outputs: list[Output]):
         self.func = func
-        self.output_dims = output_dims
-        self.output_dtypes = output_dtypes
-        # Xarray raises a confusing TypeError if output_sizes is required and isn't
-        # iterable. An empty dict will still fail, but with a better message.
-        self.output_sizes = output_sizes or {}
-        self.output_coords = output_coords
+        self.meta = _UfuncMeta.from_outputs(outputs)
 
     def __call__(
         self,
         *arrays: FeatureArray,
         skip_nodata: bool = True,
-        nodata_output: MaybeTuple[float | int] = np.nan,
+        nodata_output: MaybeTuple[float | int] | None = None,
         nan_fill: float | int | None = None,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
@@ -162,7 +166,9 @@ class FeaturewiseUfunc:
             output features. If the value does not fit in the array dtype(s) returned by
             `func`, an error will be raised unless `allow_cast` is True. When `func`
             returns multiple arrays, you can provide either a single value for all
-            arrays or a tuple with one value per output array. Defaults to np.nan.
+            arrays or a tuple with one value per output array. If not provided, NoData
+            values will fall back to those defined or inferred from the ufunc's output
+            metadata.
         nan_fill : float or int, optional
             If `skip_nodata=False`, any NaNs in the input array will be filled with this
             value prior to calling `func` to avoid errors from functions that do not
@@ -202,138 +208,92 @@ class FeaturewiseUfunc:
             DataFrame > ndarray). If multiple arrays are returned by `func`, a tuple of
             arrays will be returned.
         """
-        # Validate non-empty array inputs
-        if not arrays:
-            msg = (
-                f"{self.__class__.__name__} requires at least one feature array input."
-            )
-            raise ValueError(msg)
-
-        # Validate that all feature dimension names match
-        feature_dim_names = list(set([array.feature_dim_name for array in arrays]))
-        if len(feature_dim_names) > 1:
-            msg = (
-                "All input feature arrays must share the same feature dimension "
-                f"name. Got {feature_dim_names}."
-            )
-            raise ValueError(msg)
-        feature_dim_name = feature_dim_names[0]
-
-        nodata_inputs: list[ma.MaskedArray] = [array.nodata_input for array in arrays]
-        preprocessed = [
-            array._preprocess_ufunc_input(array.feature_array) for array in arrays
-        ]
+        call_meta = self.meta.with_inputs(
+            *arrays,
+            nodata_output=nodata_output,
+        )
 
         @with_inputs_reshaped_to_ndim(2)
         @limit_inner_threads(inner_thread_limit)
         def ufunc(*arrays: NDArray) -> MaybeTuple[NDArray]:
+            # Unwrap single-element tuples to match the output expected by
+            # xr.apply_ufunc.
             return self._apply(
                 *arrays,
                 skip_nodata=skip_nodata,
-                nodata_output=nodata_output,
-                nodata_inputs=nodata_inputs,
+                nodata_outputs=call_meta.nodata_outputs,
+                nodata_inputs=call_meta.nodata_inputs,
                 nan_fill=nan_fill,
                 ensure_min_samples=ensure_min_samples,
                 allow_cast=allow_cast,
                 check_output_for_nodata=check_output_for_nodata,
                 **ufunc_kwargs,
+            ).unwrap()
+
+        preprocessed = [
+            array._preprocess_ufunc_input(array.feature_array) for array in arrays
+        ]
+
+        raw_result = _UfuncResult(
+            xr.apply_ufunc(
+                ufunc,
+                *preprocessed,
+                dask="parallelized",
+                input_core_dims=call_meta.input_core_dims,
+                exclude_dims=call_meta.exclude_dims,
+                output_core_dims=self.meta.output_core_dims,
+                output_dtypes=self.meta.output_dtypes,
+                # Keep all attributes here to avoid dropping the spatial reference from
+                # the coordinate attributes. Unwanted attrs will be dropped during
+                # postprocessing.
+                keep_attrs=True,
+                dask_gufunc_kwargs=dict(
+                    output_sizes=self.meta.output_sizes,
+                    allow_rechunk=True,
+                ),
             )
+        )
 
-        result = xr.apply_ufunc(
-            ufunc,
-            *preprocessed,
-            dask="parallelized",
-            # All inputs must share the same feature input core dimension
-            input_core_dims=[[feature_dim_name]] * len(arrays),
-            # The feature dimension is allowed to change size, so must be excluded
-            exclude_dims=set((feature_dim_name,)),
-            output_core_dims=self.output_dims,
-            output_dtypes=self.output_dtypes,
-            # Keep all attributes here to avoid dropping the spatial reference from the
-            # coordinate attributes. Unwanted attrs will be dropped during
-            # postprocessing.
-            keep_attrs=True,
-            dask_gufunc_kwargs=dict(
-                output_sizes=self.output_sizes,
-                allow_rechunk=True,
+        return raw_result.zip_map(
+            lambda res, coords, nodata: call_meta.postprocessor(
+                res,
+                output_coords=coords,
+                nodata_output=nodata,
+                func=self.func,
+                keep_attrs=keep_attrs,
             ),
-        )
-
-        # In normal usage, xr.apply_ufunc returns the type of the highest-priority input
-        # following the type priority below. Because FeatureArray pre-processing coerces
-        # all inputs to DataArrays, we need to manually apply that logic here by
-        # having the highest priority FeatureArray post-process the output.
-        type_priority = (
-            DatasetFeatures,
-            DataArrayFeatures,
-            DataFrameFeatures,
-            NDArrayFeatures,
-        )
-        highest_priority_array = sorted(
-            arrays,
-            key=lambda arr: type_priority.index(type(arr)),
-        )[0]
-
-        # If output_coords contains a single mapping, unwrap it to avoid returning a
-        # tuple of one array.
-        output_coords = (
-            self.output_coords[0]
-            if (self.output_coords and len(self.output_coords) == 1)
-            else self.output_coords
-        )
-
-        return highest_priority_array._postprocess_ufunc_output(
-            result,
-            output_coords=output_coords,
-            nodata_output=nodata_output,
-            func=self.func,
-            keep_attrs=keep_attrs,
-        )
+            self.meta.output_coords,
+            call_meta.nodata_outputs,
+        ).unwrap()
 
     def _apply(
         self,
         *arrays: NDArray,
-        nodata_inputs: list[ma.MaskedArray],
+        nodata_inputs: tuple[ma.MaskedArray, ...],
+        nodata_outputs: tuple[float | int, ...],
         skip_nodata: bool = True,
-        nodata_output: MaybeTuple[float | int] = np.nan,
         nan_fill: float | int | None = None,
         ensure_min_samples: int = 1,
         allow_cast: bool = False,
         check_output_for_nodata: bool = True,
         **ufunc_kwargs,
-    ) -> MaybeTuple[NDArray]:
+    ) -> _UfuncResult[NDArray]:
         # Convert Numpy arrays to _UfuncInputs which handle NoData
-        uinputs = [
-            _UfuncInput(array, nodata_input=nodata)
-            for array, nodata in zip(arrays, nodata_inputs, strict=True)
-        ]
+        uinputs = _UfuncInputs(arrays, nodata_inputs=nodata_inputs)
 
-        # Only fill NaNs in the input arrays if they're not being skipped
+        # Only fill NaNs if they're not being skipped
         if nan_fill is not None and not skip_nodata:
-            for uinput in uinputs:
-                uinput.samples = uinput._fill_nans(nan_fill)
+            uinputs.fill_nans(nan_fill)
 
-        # If any input contains masked values, build a cumulative NoData mask
-        any_masked = bool(sum([array._num_masked for array in uinputs]))
-        if any_masked:
-            nodata_mask = np.stack(
-                [
-                    uinput.nodata_mask
-                    for uinput in uinputs
-                    if uinput.nodata_mask is not None
-                ],
-                axis=-1,
-            ).max(axis=-1)
-        else:
-            nodata_mask = None
+        nodata_mask = uinputs.get_nodata_mask()
 
         # Only skip NoData if there's something to skip
-        if skip_nodata and any_masked:
+        if skip_nodata and nodata_mask is not None:
             return self._apply_to_valid_samples(
-                *[uinput.samples for uinput in uinputs],
+                *uinputs.get_samples(),
                 ensure_min_samples=ensure_min_samples,
                 nodata_mask=nodata_mask,
-                nodata_output=nodata_output,
+                nodata_outputs=nodata_outputs,
                 allow_cast=allow_cast,
                 nan_fill=nan_fill,
                 check_output_for_nodata=check_output_for_nodata,
@@ -341,9 +301,9 @@ class FeaturewiseUfunc:
             )
 
         return self._apply_to_all_samples(
-            *[uinput.samples for uinput in uinputs],
+            *uinputs.get_samples(),
             nodata_mask=nodata_mask,
-            nodata_output=nodata_output,
+            nodata_outputs=nodata_outputs,
             allow_cast=allow_cast,
             check_output_for_nodata=check_output_for_nodata,
             **ufunc_kwargs,
@@ -353,17 +313,16 @@ class FeaturewiseUfunc:
         self,
         *arrays: NDArray,
         nodata_mask: NDArray | None,
-        nodata_output: MaybeTuple[float | int],
+        nodata_outputs: tuple[float | int, ...],
         allow_cast: bool,
         check_output_for_nodata: bool,
         **kwargs,
-    ) -> NDArray | tuple[NDArray, ...]:
+    ) -> _UfuncResult[NDArray]:
         """Apply a function to all samples in all arrays."""
 
-        @map_over_arguments("result", "nodata_output")
         def mask_nodata(result: NDArray, nodata_output: float | int) -> NDArray:
             """Replace NoData values in the input array with `output_nodata`."""
-            result = self._validate_nodata_output(
+            result = self._maybe_cast_for_nodata(
                 result,
                 nodata_output,
                 allow_cast=allow_cast,
@@ -373,10 +332,10 @@ class FeaturewiseUfunc:
             result[nodata_mask] = nodata_output
             return result
 
-        result = self.func(*arrays, **kwargs)
+        result = self._validate_result(self.func(*arrays, **kwargs))
 
         if nodata_mask is not None:
-            return mask_nodata(result=result, nodata_output=nodata_output)
+            return result.zip_map(mask_nodata, nodata_outputs)
 
         return result
 
@@ -384,13 +343,13 @@ class FeaturewiseUfunc:
         self,
         *arrays: NDArray,
         nodata_mask: NDArray | None,
-        nodata_output: MaybeTuple[float | int],
+        nodata_outputs: tuple[float | int, ...],
         ensure_min_samples: int,
         allow_cast: bool,
         nan_fill: float | int | None,
         check_output_for_nodata: bool,
         **kwargs,
-    ) -> NDArray | tuple[NDArray, ...]:
+    ) -> _UfuncResult[NDArray]:
         """Apply a function to all non-NoData samples in an array."""
         # Array sizes have already been validated to match
         n_samples = arrays[0].shape[0]
@@ -418,12 +377,11 @@ class FeaturewiseUfunc:
                     nan_fill if nan_fill is not None else 0
                 )
 
-        @map_over_arguments("result", "nodata_output")
         def populate_missing_samples(
             result: NDArray, nodata_output: float | int
         ) -> NDArray:
             """Insert the array result for valid samples into the full-shaped array."""
-            result = self._validate_nodata_output(
+            result = self._maybe_cast_for_nodata(
                 result,
                 nodata_output,
                 allow_cast=allow_cast,
@@ -453,10 +411,11 @@ class FeaturewiseUfunc:
             return full_result
 
         # Apply the func only to valid samples
-        func_result = self.func(*[array[~nodata_mask] for array in arrays], **kwargs)
-        return populate_missing_samples(result=func_result, nodata_output=nodata_output)
+        return self._validate_result(
+            self.func(*[array[~nodata_mask] for array in arrays], **kwargs)
+        ).zip_map(populate_missing_samples, nodata_outputs)
 
-    def _validate_nodata_output(
+    def _maybe_cast_for_nodata(
         self,
         output: NDArray,
         nodata_output: float | int,
@@ -508,3 +467,15 @@ class FeaturewiseUfunc:
             )
 
         return output
+
+    def _validate_result(self, result: MaybeTuple[NDArray]) -> _UfuncResult[NDArray]:
+        """Validate that the result from the ufunc is in the expected format."""
+        result = _UfuncResult(result)
+
+        if len(result) != self.meta.num_outputs:
+            raise ValueError(
+                f"The applied function returned {len(result)} outputs, but "
+                f"{self.meta.num_outputs} were expected based on the ufunc metadata."
+            )
+
+        return result

--- a/src/sklearn_raster/ufunc/_meta.py
+++ b/src/sklearn_raster/ufunc/_meta.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+from ..features import (
+    DataArrayFeatures,
+    DataFrameFeatures,
+    DatasetFeatures,
+    FeatureArray,
+    NDArrayFeatures,
+)
+from ..types import MaybeTuple
+
+
+@dataclass
+class Dimension:
+    """
+    A core dimension for a Ufunc output.
+
+    Parameters
+    ----------
+    name : str
+        The name of the dimension.
+    size : int, optional
+        The size of the dimension. If `coords` is provided instead, size can be inferred
+        from the number of coordinates.
+    coords : list[str] or list[int], optional
+        The coordinate values for the dimension. The number of values must be equal to
+        `size` if both are provided.
+    """
+
+    name: str
+    size: int | None = None
+    coords: Sequence[str | int] | None = None
+
+    def __post_init__(self):
+        self._infer_size_from_coords()
+
+    def _infer_size_from_coords(self) -> None:
+        if self.coords is None:
+            return
+        if not isinstance(self.coords, (list, tuple)):
+            msg = (
+                f"Dimension coordinates must be a list or tuple of values. "
+                f"Got `{self.coords.__class__.__name__}`."
+            )
+            raise ValueError(msg)
+        if self.size is None:
+            self.size = len(self.coords)
+            return
+        if self.size != len(self.coords):
+            msg = (
+                f"Dimension '{self.name}' has size {self.size} but {len(self.coords)} "
+                "coordinates. Size and coordinates must match if both are provided."
+            )
+            raise ValueError(msg)
+
+
+@dataclass
+class Output:
+    """
+    Metadata for a single output array from a Ufunc.
+
+    Parameters
+    ----------
+    dims : list[Dimension]
+        The core dimensions of the output.
+    dtype : np.dtype, optional
+        The output data type.
+    nodata : float or int, optional
+        The value used to encode NoData in the output array. If not provided, it will
+        be inferred from the data type if possible (NaN for floating point types,
+        minimum value for signed integers, and maximum value for unsigned integers).
+    """
+
+    dims: list[Dimension]
+    dtype: np.dtype | None
+    nodata: float | int
+
+    def __init__(
+        self,
+        dims: list[Dimension],
+        dtype: np.dtype | None = None,
+        nodata: float | int | None = None,
+    ):
+        self.dims = dims
+        self.dtype = dtype
+        self.nodata = self._infer_nodata_from_dtype(nodata)
+
+    def _infer_nodata_from_dtype(self, nodata: float | int | None) -> float | int:
+        """Attempt to infer the NoData value from the data type."""
+        if nodata is not None:
+            return nodata
+        if self.dtype is not None:
+            if np.issubdtype(self.dtype, np.floating):
+                return np.dtype(self.dtype).type(np.nan)
+            if np.issubdtype(self.dtype, np.unsignedinteger):
+                return np.iinfo(self.dtype).max
+            if np.issubdtype(self.dtype, np.signedinteger):
+                return np.iinfo(self.dtype).min
+
+        raise ValueError("NoData value could not be inferred. Please provide `nodata`.")
+
+    @classmethod
+    def from_1d(
+        cls,
+        name: str,
+        size: int | None = None,
+        coords: Sequence[str | int] | None = None,
+        dtype: np.dtype | None = None,
+        nodata: float | int | None = None,
+    ) -> Output:
+        """
+        Construct metadata for a ufunc with a single core output dimension.
+
+        Parameters
+        ----------
+        name : str
+            The name of the core dimension.
+        size : int, optional
+            The size of the dimension. If `coords` is provided instead, size can be
+            inferred from the number of coordinates.
+        coords : list[str] or list[int], optional
+            The coordinate values for the dimension. The number of values must be equal
+            to `size` if both are provided.
+        dtype : np.dtype, optional
+            The output data type.
+        nodata : float or int, optional
+            The value used to encode NoData in the output array. If not provided, it
+            will be inferred from the data type if possible (NaN for floating point
+            types, minimum value for signed integers, and maximum value for unsigned
+            integers).
+
+        Returns
+        -------
+        Output
+            An Output instance with the specified core dimension and data type.
+        """
+        return cls(
+            dims=[Dimension(name=name, size=size, coords=coords)],
+            dtype=dtype,
+            nodata=nodata,
+        )
+
+
+@dataclass
+class _UfuncMeta:
+    """Metadata describing the outputs returned by a ufunc."""
+
+    num_outputs: int
+    output_sizes: dict[str, int]
+    output_dtypes: tuple[type[np.generic] | None, ...]
+    output_core_dims: tuple[list[str], ...]
+    output_coords: tuple[dict[str, Sequence[str | int]], ...]
+    nodata_outputs: tuple[float | int, ...]
+
+    @staticmethod
+    def _get_output_sizes(outputs: list[Output]) -> dict[str, int]:
+        """Get a mapping from dimension names to sizes for all output dimensions."""
+        output_sizes: dict[str, int] = {}
+        for output in outputs:
+            for dim in output.dims:
+                if dim.size is None:
+                    continue
+
+                if dim.name in output_sizes and output_sizes[dim.name] != dim.size:
+                    # NOTE: This is a dask.apply_gufunc constraint since sizes are
+                    # passed as a single dict per call rather than per output. We may
+                    # be able to relax this in non-Dask cases.
+                    msg = (
+                        "Different sizes for the same dimension are not supported. "
+                        f"Found dimension '{dim.name}' with sizes "
+                        f"{output_sizes[dim.name]} and {dim.size}."
+                    )
+                    raise ValueError(msg)
+                output_sizes[dim.name] = dim.size
+        return output_sizes
+
+    @staticmethod
+    def _get_output_dtypes(
+        outputs: list[Output],
+    ) -> tuple[type[np.generic] | None, ...]:
+        """Get a list of output data types for each output array."""
+        return tuple([output.dtype for output in outputs])
+
+    @staticmethod
+    def _get_output_core_dims(outputs: list[Output]) -> tuple[list[str], ...]:
+        """Get a list of output core dimension names for each output array."""
+        return tuple([[dim.name for dim in output.dims] for output in outputs])
+
+    @staticmethod
+    def _get_output_coords(
+        outputs: list[Output],
+    ) -> tuple[dict[str, Sequence[str | int]], ...]:
+        return tuple(
+            [
+                {dim.name: dim.coords for dim in output.dims if dim.coords is not None}
+                for output in outputs
+            ]
+        )
+
+    @classmethod
+    def from_outputs(cls, outputs: list[Output]) -> _UfuncMeta:
+        """Construct ufunc metadata from a list of outputs."""
+        return cls(
+            num_outputs=len(outputs),
+            output_sizes=cls._get_output_sizes(outputs),
+            output_dtypes=cls._get_output_dtypes(outputs),
+            output_core_dims=cls._get_output_core_dims(outputs),
+            output_coords=cls._get_output_coords(outputs),
+            nodata_outputs=tuple(output.nodata for output in outputs),
+        )
+
+    def with_inputs(
+        self,
+        *arrays: FeatureArray,
+        nodata_output: MaybeTuple[float | int] | None = None,
+    ) -> _CalledUfuncMeta:
+        """Extend the UfuncMeta with call-specific input metadata."""
+        return _CalledUfuncMeta.from_call(
+            *arrays,
+            ufunc_meta=self,
+            nodata_output=nodata_output,
+        )
+
+
+@dataclass
+class _CalledUfuncMeta(_UfuncMeta):
+    """Extension of UfuncMeta that includes call-specific input metadata."""
+
+    feature_dim_name: str | None
+    nodata_inputs: tuple[float | int]
+    input_core_dims: tuple[list[str | None], ...]
+    exclude_dims: set[str | None]
+    postprocessor: Callable
+
+    @classmethod
+    def from_call(
+        cls,
+        *arrays: FeatureArray,
+        ufunc_meta: _UfuncMeta,
+        nodata_output: MaybeTuple[float | int] | None,
+    ):
+        feature_dim_name = cls._get_feature_dim_name(arrays)
+
+        # Start with the base ufunc metadata
+        base_meta = ufunc_meta.__dict__.copy()
+        # Drop the default nodata_outputs since they're overriden with called values
+        base_meta.pop("nodata_outputs")
+
+        return cls(
+            **base_meta,
+            feature_dim_name=feature_dim_name,
+            nodata_outputs=cls._get_nodata_outputs(ufunc_meta, nodata_output),
+            nodata_inputs=tuple(array.nodata_input for array in arrays),
+            input_core_dims=tuple([[feature_dim_name]] * len(arrays)),
+            # The feature dimension is allowed to change size, so must be excluded
+            exclude_dims=set((feature_dim_name,)),
+            postprocessor=cls._get_postprocessor(arrays),
+        )
+
+    @staticmethod
+    def _get_feature_dim_name(arrays: tuple[FeatureArray, ...]) -> str | None:
+        """Validate the feature dimension name and return it."""
+        # Validate non-empty array inputs
+        if not arrays:
+            raise ValueError("Ufuncs requires at least one feature array input.")
+
+        # Validate that all feature dimension names match
+        feature_dim_names = list(set([array.feature_dim_name for array in arrays]))
+        if len(feature_dim_names) > 1:
+            msg = (
+                "All input feature arrays must share the same feature dimension "
+                f"name. Got {feature_dim_names}."
+            )
+            raise ValueError(msg)
+
+        return feature_dim_names[0]
+
+    @staticmethod
+    def _get_nodata_outputs(
+        ufunc_meta: _UfuncMeta, nodata_output: MaybeTuple[float | int] | None
+    ) -> tuple[float | int, ...]:
+        """
+        Take optional user-provided NoData output value(s) and use them to override
+        the default NoData output value(s) defined in the ufunc metadata.
+        """
+        # Default to NoData values defined in the ufunc metadata
+        if nodata_output is None:
+            return ufunc_meta.nodata_outputs
+        # Broadcast single values to multiple outputs
+        if not isinstance(nodata_output, (list, tuple)):
+            return tuple([nodata_output] * ufunc_meta.num_outputs)
+        # Validate that multiple values match the number of outputs
+        if len(nodata_output) != ufunc_meta.num_outputs:
+            raise ValueError(
+                f"The ufunc defines {ufunc_meta.num_outputs} outputs, but "
+                f"{len(nodata_output)} `nodata_output` values were provided."
+            )
+        return tuple(nodata_output)
+
+    @staticmethod
+    def _get_postprocessor(arrays: tuple[FeatureArray, ...]) -> Callable:
+        # In normal usage, xr.apply_ufunc returns the type of the highest-priority input
+        # following the type priority below. Because FeatureArray pre-processing coerces
+        # all inputs to DataArrays, we need to manually apply that logic here by
+        # having the highest priority FeatureArray post-process the output.
+        type_priority = (
+            DatasetFeatures,
+            DataArrayFeatures,
+            DataFrameFeatures,
+            NDArrayFeatures,
+        )
+        highest_priority_array = sorted(
+            arrays,
+            key=lambda arr: type_priority.index(type(arr)),
+        )[0]
+        return highest_priority_array._postprocess_ufunc_output

--- a/src/sklearn_raster/utils/decorators.py
+++ b/src/sklearn_raster/utils/decorators.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
-from inspect import signature
 from typing import TYPE_CHECKING, Concatenate
 
 import threadpoolctl
@@ -10,6 +9,7 @@ from numpy.typing import NDArray
 from sklearn.utils.validation import check_is_fitted
 
 from ..types import RT, MaybeTuple, P
+from .ufunc import _UfuncResult
 
 if TYPE_CHECKING:
     from ..estimator import FeatureArrayEstimator
@@ -77,109 +77,6 @@ def requires_attributes(
         return wrapper
 
     return decorator
-
-
-def map_over_arguments(
-    *map_args: str,
-    mappable=(tuple, list),
-    validate_args=True,
-):
-    """
-    A decorator that allows a function to map over selected arguments.
-
-    When the selected arguments are mappable, the function will be called once with
-    each value and a tuple of results will be returned. Non-mapped arguments and scalar
-    mapped arguments will be passed to each call.
-
-    Parameters
-    ----------
-    map_args : str
-        The names of the arguments to support mapping over.
-    mappable : tuple[type], default (list, tuple)
-        The types that will be mapped over when passed to a mapped argument.
-    validate_args : bool, default True
-        If True, the decorator will check that all mapped arguments are defined as
-        parameters of the decorated function and raise a ValueError if not.
-
-    Examples
-    --------
-
-    Providing an iterable to a mapped argument will return a tuple of results mapped
-    over each value:
-
-    >>> @map_over_arguments('b')
-    ... def func(a, b):
-    ...     return a + b
-    >>> func(1, b=[2, 3])
-    (3, 4)
-
-    When multiple arguments are mapped, they will be mapped together:
-
-    >>> @map_over_arguments('a', 'b')
-    ... def func(a, b):
-    ...     return a + b
-    >>> func(a=[1, 2], b=[3, 4])
-    (4, 6)
-
-    Providing a mapped argument as a scalar will disable mapping over that argument:
-
-    >>> @map_over_arguments('a', 'b')
-    ... def func(a, b):
-    ...     return a + b
-    >>> func(a=1, b=[2, 3])
-    (3, 4)
-    >>> func(a=1, b=2)
-    3
-    """
-
-    def arg_mapper(func: Callable[P, RT]) -> Callable[P, MaybeTuple[RT]]:
-        if validate_args:
-            accepted_args = signature(func).parameters
-            invalid_args = [arg for arg in map_args if arg not in accepted_args]
-            if invalid_args:
-                msg = (
-                    "The following arguments are not accepted by the decorated "
-                    f"function and cannot be mapped over: {invalid_args}"
-                )
-                raise ValueError(msg)
-
-        def wrapper(*args, **kwargs):
-            # Bind the arguments as they will be called to allow mapping over positional
-            # or keyword arguments.
-            bound_args = signature(func).bind(*args, **kwargs)
-            bound_args.apply_defaults()
-
-            # Collect the mapped arguments that have mappable values
-            to_map = {
-                arg: val
-                for arg, val in bound_args.arguments.items()
-                if arg in map_args and isinstance(val, mappable)
-            }
-            if not to_map:
-                return func(*args, **kwargs)
-
-            num_mapped_vals = [len(v) for v in to_map.values()]
-            if any([val < max(num_mapped_vals) for val in num_mapped_vals]):
-                raise ValueError(
-                    "All mapped arguments must be the same length or scalar."
-                )
-
-            # Group the mapped arguments for each call
-            map_groups = [
-                {**{k: v[i] for k, v in to_map.items()}}
-                for i in range(max(num_mapped_vals))
-            ]
-
-            # Return one result per group of mapped values
-            results = []
-            for map_group in map_groups:
-                bound_args.arguments.update(map_group)
-                results.append(func(*bound_args.args, **bound_args.kwargs))
-            return tuple(results)
-
-        return wrapper
-
-    return arg_mapper
 
 
 def _get_threadpool_controller() -> threadpoolctl.ThreadpoolController:
@@ -287,7 +184,6 @@ def with_inputs_reshaped_to_ndim(ndim: int | None):
             if ndim_in == ndim:
                 return func(*arrays, **kwargs)
 
-            @map_over_arguments("out")
             def restore_dimensions(out: NDArray) -> NDArray:
                 # For the output shape to be solvable, only one dimension can change.
                 # Since we flatten/expand from the left, we allow the rightmost final
@@ -296,8 +192,11 @@ def with_inputs_reshaped_to_ndim(ndim: int | None):
                 return out.reshape(shape_out)
 
             reshaped = [_reshape_to_ndim(a, ndim) for a in arrays]
-            result = func(*reshaped, **kwargs)
-            return restore_dimensions(result)
+            # Wrap the function output in a tuple to unify handling single vs.
+            # multiple outputs, then unwrap it to match the function signature
+            return (
+                _UfuncResult(func(*reshaped, **kwargs)).map(restore_dimensions).unwrap()
+            )
 
         return validate_and_reshape
 

--- a/src/sklearn_raster/utils/ufunc.py
+++ b/src/sklearn_raster/utils/ufunc.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Collection
+from typing import Generic
+
+from ..types import RT, MaybeTuple, T
+
+
+class _UfuncResult(Generic[T]):
+    """A monadic wrapper around a ufunc result as a single value or tuple of values."""
+
+    def __init__(self, result: MaybeTuple[T]):
+        self._items: tuple[T, ...] = result if isinstance(result, tuple) else (result,)
+        if len(self) == 0:
+            raise ValueError("UfuncResult must be non-empty.")
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def map(self, func: Callable[..., RT], **kwargs) -> _UfuncResult[RT]:
+        """Map func over the results."""
+        return _UfuncResult(tuple(func(item, **kwargs) for item in self._items))
+
+    def zip_map(
+        self,
+        func: Callable[..., RT],
+        *iters: Collection[object],
+        **kwargs,
+    ) -> _UfuncResult[RT]:
+        """Zip results with additional iterables, then map the function over them."""
+        if not iters:
+            return self.map(func, **kwargs)
+
+        result_length = len(self)
+        iter_lengths = [len(it) for it in iters]
+        if not all(result_length == il for il in iter_lengths):
+            raise ValueError(
+                "All iterables passed to `zip_map` must have the same length. "
+                f"Result has length {result_length} but iterables have lengths "
+                f"{iter_lengths}."
+            )
+        return _UfuncResult(
+            tuple(
+                func(*args, **kwargs) for args in zip(self._items, *iters, strict=True)
+            )
+        )
+
+    def unwrap(self) -> MaybeTuple[T]:
+        """Unwrap the result to a single value or a tuple of multiple values."""
+        return self._items if len(self) > 1 else self._items[0]

--- a/tests/test_ufunc.py
+++ b/tests/test_ufunc.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_array_equal
 
 from sklearn_raster.features import FeatureArray
 from sklearn_raster.types import FeatureArrayType
-from sklearn_raster.ufunc import FeaturewiseUfunc
+from sklearn_raster.ufunc import FeaturewiseUfunc, Output
 from sklearn_raster.utils.features import get_minimum_precise_numeric_dtype
 
 from .feature_utils import (
@@ -37,9 +37,7 @@ def test_ufunc_with_multiple_inputs(
 
     ufunc = FeaturewiseUfunc(
         lambda *args: sum(args),
-        output_dims=[["variable"]],
-        output_sizes={"variable": 1},
-        output_dtypes=[input_arrays[0].dtype],
+        outputs=[Output.from_1d("variable", size=1, dtype=input_arrays[0].dtype)],
     )
     result = unwrap_features(ufunc(*input_features))
     expected_output = np.full((1, 2, 2), n_inputs)
@@ -90,9 +88,7 @@ def test_ufunc_propagates_nodata_from_inputs(
 
     ufunc = FeaturewiseUfunc(
         lambda x, y, z: x + y + z,
-        output_dims=[["variable"]],
-        output_sizes={"variable": 1},
-        output_dtypes=[d1.dtype],
+        outputs=[Output.from_1d("variable", size=1, dtype=d1.dtype)],
     )
     result = unwrap_features(
         ufunc(f1, f2, f3, skip_nodata=skip_nodata, nodata_output=-99)
@@ -113,9 +109,7 @@ def test_ufunc_raises_with_no_inputs():
     """Test that calling a ufunc without any arrays raises an error."""
     ufunc = FeaturewiseUfunc(
         lambda: None,
-        output_dims=[["variable"]],
-        output_sizes={"variable": 1},
-        output_dtypes=[np.float64],
+        outputs=[Output.from_1d("variable", size=1, dtype=np.dtype(np.float64))],
     )
     with pytest.raises(ValueError, match="requires at least one feature array input"):
         ufunc()
@@ -129,10 +123,10 @@ def test_ufunc_sets_explicit_output_coords(dims):
 
     ufunc = FeaturewiseUfunc(
         lambda x: (x, x),
-        output_dims=[[dims[0]], [dims[1]]],
-        output_sizes={dims[0]: 3, dims[1]: 3},
-        output_dtypes=[a.dtype, a.dtype],
-        output_coords=[{dims[0]: ["a0", "a1", "a2"]}, {dims[1]: ["b0", "b1", "b2"]}],
+        outputs=[
+            Output.from_1d(dims[0], coords=["a0", "a1", "a2"], dtype=a.dtype),
+            Output.from_1d(dims[1], coords=["b0", "b1", "b2"], dtype=a.dtype),
+        ],
     )
     r1, r2 = ufunc(features)
 
@@ -147,9 +141,10 @@ def test_ufunc_sets_implicit_output_coords():
 
     ufunc = FeaturewiseUfunc(
         lambda x: (x, x),
-        output_dims=[["foo"], ["bar"]],
-        output_sizes={"foo": 3, "bar": 3},
-        output_dtypes=[a.dtype, a.dtype],
+        outputs=[
+            Output.from_1d("foo", size=3, dtype=a.dtype),
+            Output.from_1d("bar", size=3, dtype=a.dtype),
+        ],
     )
     r1, r2 = ufunc(features)
 
@@ -187,10 +182,13 @@ def test_ufunc_return_type_priority(
 
     ufunc = FeaturewiseUfunc(
         lambda *x: x[0],
-        output_dims=[["variable"]],
-        output_sizes={"variable": n_features},
-        output_coords=[{"variable": [f"b{i}" for i in range(n_features)]}],
-        output_dtypes=[np.dtype(np.float64)],
+        outputs=[
+            Output.from_1d(
+                "variable",
+                coords=[f"b{i}" for i in range(n_features)],
+                dtype=np.dtype(np.float64),
+            ),
+        ],
     )
 
     assert isinstance(ufunc(*features), expected_type)
@@ -210,9 +208,7 @@ def test_ufunc_does_not_mutate_input(
     features = FeatureArray.from_feature_array(array, nodata_input=0)
     FeaturewiseUfunc(
         lambda x: x * 2.0,
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )(features, skip_nodata=skip_nodata)
 
     assert_array_equal(a, original_array)
@@ -241,9 +237,7 @@ def test_ufunc_raises_with_unsupported_nodata_output_dtype(
     )
     ufunc = FeaturewiseUfunc(
         lambda x: np.ones_like(x).astype(return_dtype),
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     with pytest.raises(ValueError, match=re.escape(expected_msg)):
         # Unwrap to force computation for lazy arrays
@@ -273,9 +267,7 @@ def test_ufunc_raises_with_unsupported_nodata_output_float_precision(
     expected_msg = "Consider casting `nodata_output` to a lower precision"
     ufunc = FeaturewiseUfunc(
         lambda x: np.ones_like(x).astype(return_dtype),
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     with pytest.raises(ValueError, match=expected_msg):
         # Unwrap to force computation for lazy arrays
@@ -307,9 +299,7 @@ def test_ufunc_allows_casting_of_unsupported_nodata_output(
     # Unwrap to force computation for lazy arrays
     ufunc = FeaturewiseUfunc(
         lambda x: np.ones_like(x).astype(output_dtype),
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     result = unwrap_features(
         ufunc(
@@ -337,9 +327,7 @@ def test_ufunc_skips_nodata_output_validation_if_unmasked(
 
     ufunc = FeaturewiseUfunc(
         lambda x: x,
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     # Unwrap to force computation for lazy arrays
     unwrap_features(
@@ -374,9 +362,7 @@ def test_ufunc_sets_nodata_output(
     )
     ufunc = FeaturewiseUfunc(
         lambda x: x,
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     result = ufunc(
         features,
@@ -385,6 +371,46 @@ def test_ufunc_sets_nodata_output(
     )
 
     assert_array_equal(unwrap_features(result), expected_output)
+
+
+def test_ufunc_uses_default_nodata_output():
+    """Test that the nodata defined in the ufunc metadata is used when not provided."""
+    nodata_output = -99.0
+    a = np.array([[[np.nan, 1, np.nan]]])
+    expected_output = np.array([[[nodata_output, 1, nodata_output]]])
+    features = FeatureArray.from_feature_array(a)
+
+    ufunc = FeaturewiseUfunc(
+        lambda x: x,
+        outputs=[Output.from_1d("variable", size=a.shape[0], nodata=nodata_output)],
+    )
+    result = ufunc(
+        features,
+        skip_nodata=True,
+    )
+
+    assert_array_equal(result, expected_output)
+
+
+def test_ufunc_overrides_default_nodata_output():
+    """Test that the nodata defined in the ufunc metadata is overriden when provided."""
+    nodata_output = -99.0
+    override_nodata = -32768.0
+    a = np.array([[[np.nan, 1, np.nan]]])
+    expected_output = np.array([[[override_nodata, 1, override_nodata]]])
+    features = FeatureArray.from_feature_array(a)
+
+    ufunc = FeaturewiseUfunc(
+        lambda x: x,
+        outputs=[Output.from_1d("variable", size=a.shape[0], nodata=nodata_output)],
+    )
+    result = ufunc(
+        features,
+        skip_nodata=True,
+        nodata_output=override_nodata,
+    )
+
+    assert_array_equal(result, expected_output)
 
 
 @pytest.mark.parametrize("n_features", [1, 2])
@@ -406,9 +432,7 @@ def test_ufunc_shape_when_squeezing_dimension(
     ufunc = FeaturewiseUfunc(
         lambda x: x.mean(axis=1, keepdims=False),
         # Squeeze out the feature dimension (like a single-output predict method would)
-        output_dims=[["variable"]],
-        output_sizes={"variable": 1},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=1, dtype=a.dtype)],
     )
     result = ufunc(
         features,
@@ -435,9 +459,7 @@ def test_ufunc_warns_when_returning_nodata(
     )
     ufunc = FeaturewiseUfunc(
         lambda x: np.full_like(x, nodata_output),
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     with pytest.warns(UserWarning, match=f"{nodata_output} was found in the array"):
         unwrap_features(
@@ -466,9 +488,7 @@ def test_ufunc_ensures_min_samples(
     )
     ufunc = FeaturewiseUfunc(
         lambda x: assert_array_size(x, min_samples),
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     result = ufunc(
         features,
@@ -491,9 +511,7 @@ def test_ufunc_raises_on_ensure_too_many_samples(
     )
     ufunc = FeaturewiseUfunc(
         lambda x: x,
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     with pytest.raises(ValueError, match="Cannot ensure 50 samples with only 10"):
         unwrap_features(
@@ -530,9 +548,7 @@ def test_ufunc_ensure_min_samples_does_not_overwrite(
     )
     ufunc = FeaturewiseUfunc(
         check_for_valid_sample,
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     result = unwrap_features(
         ufunc(
@@ -572,9 +588,7 @@ def test_ufunc_skips_nodata(
     )
     ufunc = FeaturewiseUfunc(
         lambda x: assert_array_size(x, num_valid),
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     result = ufunc(
         features,
@@ -604,9 +618,7 @@ def test_ufunc_fills_nans(
 
     ufunc = FeaturewiseUfunc(
         nan_check,
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     result = ufunc(
         features,
@@ -627,9 +639,7 @@ def test_ufunc_sets_dataarray_fillvalue(nodata_output: int | float):
 
     ufunc = FeaturewiseUfunc(
         lambda x: x,
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     result = ufunc(
         features,
@@ -656,9 +666,7 @@ def test_ufunc_sets_dataset_fillvalue(nodata_output: int | float):
 
     ufunc = FeaturewiseUfunc(
         lambda x: x,
-        output_dims=[["variable"]],
-        output_sizes={"variable": a.shape[0]},
-        output_dtypes=[a.dtype],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
     )
     result = ufunc(
         features,
@@ -686,8 +694,7 @@ def test_ufunc_raises_on_missing_output_sizes(
     )
     ufunc = FeaturewiseUfunc(
         lambda x: x,
-        output_dims=[["variable"]],
-        output_sizes=None,
+        outputs=[Output.from_1d("variable", dtype=np.uint8)],
     )
     with pytest.raises(ValueError, match=re.escape(msg)):
         ufunc(features)
@@ -697,7 +704,7 @@ def test_ufunc_raises_on_missing_arrays():
     """Test that applying a ufunc without any arrays raises an error."""
     ufunc = FeaturewiseUfunc(
         lambda x: x,
-        output_dims=[["variable"]],
+        outputs=[Output.from_1d("variable", size=1, dtype=np.dtype(np.float64))],
     )
     with pytest.raises(ValueError, match="requires at least one feature array input"):
         ufunc()
@@ -717,7 +724,7 @@ def test_ufunc_raises_on_mismatched_feature_dim_names():
 
     ufunc = FeaturewiseUfunc(
         lambda x, y: x + y,
-        output_dims=[["variable"]],
+        outputs=[Output.from_1d("variable", size=1, dtype=np.dtype(np.float64))],
     )
     with pytest.raises(
         ValueError,
@@ -736,7 +743,13 @@ def test_ufunc_raises_on_mismatched_shapes():
 
     ufunc = FeaturewiseUfunc(
         lambda x, y: x + y,
-        output_dims=[["variable"]],
+        outputs=[
+            Output.from_1d(
+                "variable",
+                size=a.shape[0],
+                dtype=np.dtype(np.float64),
+            )
+        ],
     )
     with pytest.raises(ValueError, match="All arrays must have the same shape"):
         ufunc(features_a, features_b)
@@ -752,7 +765,13 @@ def test_ufunc_broadcasts_feature_dimensions():
 
     ufunc = FeaturewiseUfunc(
         lambda x, y: x + y,
-        output_dims=[["variable"]],
+        outputs=[
+            Output.from_1d(
+                "variable",
+                size=b.shape[0],
+                dtype=np.dtype(np.float64),
+            )
+        ],
     )
     result = ufunc(features_a, features_b)
     assert result.shape == (5, 10)
@@ -777,7 +796,7 @@ def test_ufunc_applied_with_inner_thread_limit(thread_limit: int):
 
     ufunc = FeaturewiseUfunc(
         check_inner_threads,
-        output_dims=[["variable"]],
+        outputs=[Output.from_1d("variable", size=1, dtype=np.dtype(np.float64))],
     )
     ufunc(
         features,

--- a/tests/test_ufunc_meta.py
+++ b/tests/test_ufunc_meta.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from sklearn_raster.features import FeatureArray
+from sklearn_raster.ufunc._meta import Dimension, Output, _UfuncMeta
+
+from .feature_utils import wrap_features
+
+
+def test_ufuncmeta_attributes_with_multiple_dimensions():
+    outputs = [
+        Output(
+            dims=[
+                Dimension(name="x", size=2, coords=["x0", "x1"]),
+                Dimension(name="y", size=3, coords=["y0", "y1", "y2"]),
+            ],
+            dtype=np.float32,
+            nodata=-999.0,
+        ),
+    ]
+
+    meta = _UfuncMeta.from_outputs(outputs)
+
+    assert meta.output_sizes == {"x": 2, "y": 3}
+    assert meta.output_dtypes == (np.float32,)
+    assert meta.output_core_dims == (["x", "y"],)
+    assert meta.output_coords == ({"x": ["x0", "x1"], "y": ["y0", "y1", "y2"]},)
+    assert meta.nodata_outputs == (-999.0,)
+
+
+def test_ufuncmeta_attributes_with_multiple_outputs():
+    meta = _UfuncMeta.from_outputs(
+        [
+            Output(
+                dims=[Dimension(name="foo", size=2, coords=["x0", "x1"])],
+                dtype=np.float32,
+                nodata=-999.0,
+            ),
+            Output(
+                dims=[Dimension(name="bar", size=1, coords=None)],
+                dtype=np.uint8,
+                nodata=0,
+            ),
+        ]
+    )
+
+    assert meta.output_sizes == {"foo": 2, "bar": 1}
+    assert meta.output_dtypes == (np.float32, np.uint8)
+    assert meta.output_core_dims == (["foo"], ["bar"])
+    assert meta.output_coords == ({"foo": ["x0", "x1"]}, {})
+    assert meta.nodata_outputs == (-999.0, 0)
+
+
+def test_output_from_1d_constructs_dimension():
+    meta = Output.from_1d(
+        name="variable",
+        size=3,
+        coords=["a", "b", "c"],
+        dtype=np.dtype(np.float32),
+        nodata=-999.0,
+    )
+
+    assert len(meta.dims) == 1
+    assert meta.dims[0] == Dimension(name="variable", size=3, coords=["a", "b", "c"])
+    assert meta.dtype == np.dtype(np.float32)
+    assert meta.nodata == -999.0
+
+
+def test_ufuncmeta_attributes_with_none():
+    meta = _UfuncMeta.from_outputs(
+        [
+            Output(
+                dims=[
+                    Dimension(name="foo", size=None, coords=None),
+                    Dimension(name="bar", size=3, coords=["a", "b", "c"]),
+                ],
+                nodata=0,
+            ),
+        ]
+    )
+
+    assert "foo" in meta.output_core_dims[0]
+    # Dimensions with None should be omitted from sizes and coords
+    assert meta.output_sizes == {"bar": 3}
+    assert meta.output_coords == ({"bar": ["a", "b", "c"]},)
+    # Outputs with None should be included in dtypes and nodata_outputs
+    assert meta.output_dtypes == (None,)
+    assert meta.nodata_outputs == (0,)
+
+
+def test_ufuncmeta_merges_sizes_across_outputs():
+    meta = _UfuncMeta.from_outputs(
+        [
+            Output(dims=[Dimension(name="k", size=3)], nodata=0),
+            Output(dims=[Dimension(name="k", size=3)], nodata=0),
+        ]
+    )
+
+    assert meta.output_sizes == {"k": 3}
+
+
+def test_ufuncmeta_raises_on_conflicting_dim_sizes():
+    outputs = [
+        Output(dims=[Dimension(name="k", size=3)], nodata=0),
+        Output(dims=[Dimension(name="k", size=4)], nodata=0),
+    ]
+
+    expected_msg = (
+        "Different sizes for the same dimension are not supported. "
+        "Found dimension 'k' with sizes 3 and 4."
+    )
+
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
+        _UfuncMeta.from_outputs(outputs)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_nodata"),
+    [
+        (np.float32, np.float32(np.nan)),
+        (np.float64, np.float64(np.nan)),
+        (np.int16, -32768),
+        (np.uint8, 255),
+    ],
+)
+def test_ufuncmeta_infers_nodata_from_dtype(dtype, expected_nodata):
+    meta = Output(dims=[Dimension(name="x", size=2)], dtype=dtype)
+    if np.issubdtype(dtype, np.floating):
+        assert np.isnan(meta.nodata)
+        assert np.dtype(meta.nodata).type == np.dtype(dtype).type
+    else:
+        assert meta.nodata == expected_nodata
+
+
+@pytest.mark.parametrize("dtype", [np.dtype(str), None])
+def test_ufuncmeta_raises_if_nodata_cannot_be_inferred(dtype):
+    expected_msg = "NoData value could not be inferred. Please provide `nodata`."
+
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
+        Output(dims=[Dimension(name="x", size=2)], dtype=dtype)
+
+
+def test_dimension_infers_size_from_coords():
+    assert Dimension(name="k", size=None, coords=["a", "b", "c"]).size == 3
+
+
+def test_dimension_raises_if_size_inconsistent_with_coords():
+    expected_msg = "Dimension 'k' has size 2 but 3 coordinates."
+
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
+        Dimension(name="k", size=2, coords=["a", "b", "c"])
+
+
+@pytest.mark.parametrize("coords", [42, "foo", {"x": 1}])
+def test_dimension_raises_if_coords_not_tuple_or_list(coords):
+    expected_msg = (
+        "Dimension coordinates must be a list or tuple of values. Got "
+        f"`{coords.__class__.__name__}`."
+    )
+
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
+        Dimension(name="k", size=None, coords=coords)
+
+
+def test_with_inputs_constructs_called_meta_with_defaults():
+    ufunc_meta = _UfuncMeta.from_outputs(
+        [
+            Output(
+                dims=[Dimension(name="target", size=2)],
+                dtype=np.float32,
+                nodata=-1.0,
+            )
+        ]
+    )
+    features = FeatureArray.from_feature_array(
+        wrap_features(np.ones((2, 3, 4)), type=xr.DataArray),
+        nodata_input=[-10.0, -20.0],
+    )
+
+    called_meta = ufunc_meta.with_inputs(features)
+
+    assert called_meta.num_outputs == 1
+    assert called_meta.output_sizes == {"target": 2}
+    assert called_meta.output_core_dims == (["target"],)
+    assert called_meta.output_dtypes == (np.float32,)
+    assert called_meta.nodata_outputs == (-1.0,)
+    assert called_meta.feature_dim_name == "variable"
+    assert called_meta.input_core_dims == (["variable"],)
+    assert called_meta.exclude_dims == {"variable"}
+    assert len(called_meta.nodata_inputs) == 1
+    assert called_meta.nodata_inputs[0].data.tolist() == [-10.0, -20.0]
+    assert called_meta.nodata_inputs[0].mask.tolist() == [False, False]
+
+
+def test_with_inputs_overrides_nodata_outputs_scalar_and_sequence():
+    ufunc_meta = _UfuncMeta.from_outputs(
+        [
+            Output(dims=[Dimension(name="a", size=1)], dtype=np.float32, nodata=-1.0),
+            Output(dims=[Dimension(name="b", size=1)], dtype=np.uint8, nodata=255),
+        ]
+    )
+    features = FeatureArray.from_feature_array(
+        wrap_features(np.ones((2, 5)), type=xr.DataArray)
+    )
+
+    called_scalar = ufunc_meta.with_inputs(features, nodata_output=-999)
+    assert called_scalar.nodata_outputs == (-999, -999)
+
+    called_seq = ufunc_meta.with_inputs(features, nodata_output=(-7, 7))
+    assert called_seq.nodata_outputs == (-7, 7)
+
+
+def test_with_inputs_raises_on_invalid_nodata_output_length():
+    ufunc_meta = _UfuncMeta.from_outputs(
+        [
+            Output(dims=[Dimension(name="a", size=1)], dtype=np.float32, nodata=-1.0),
+            Output(dims=[Dimension(name="b", size=1)], dtype=np.uint8, nodata=255),
+        ]
+    )
+    features = FeatureArray.from_feature_array(
+        wrap_features(np.ones((2, 5)), type=xr.DataArray)
+    )
+
+    expected_msg = (
+        "The ufunc defines 2 outputs, but 1 `nodata_output` values were provided."
+    )
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
+        ufunc_meta.with_inputs(features, nodata_output=(1,))
+
+
+def test_with_inputs_raises_on_empty_inputs():
+    ufunc_meta = _UfuncMeta.from_outputs(
+        [Output(dims=[Dimension(name="a", size=1)], dtype=np.float32, nodata=-1.0)]
+    )
+
+    expected_msg = "Ufuncs requires at least one feature array input."
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
+        ufunc_meta.with_inputs()
+
+
+def test_with_inputs_raises_on_mismatched_feature_dim_names():
+    ufunc_meta = _UfuncMeta.from_outputs(
+        [Output(dims=[Dimension(name="a", size=1)], dtype=np.float32, nodata=-1.0)]
+    )
+    a = FeatureArray.from_feature_array(
+        xr.DataArray(np.ones((2, 3, 4)), dims=["variable", "y", "x"])
+    )
+    b = FeatureArray.from_feature_array(
+        xr.DataArray(np.ones((2, 3, 4)), dims=["band", "y", "x"])
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="All input feature arrays must share the same feature dimension name",
+    ):
+        ufunc_meta.with_inputs(a, b)
+
+
+def test_with_inputs_uses_highest_priority_postprocessor():
+    ufunc_meta = _UfuncMeta.from_outputs(
+        [Output(dims=[Dimension(name="a", size=1)], dtype=np.float32, nodata=-1.0)]
+    )
+    df_features = FeatureArray.from_feature_array(
+        wrap_features(np.ones((2, 5)), type=pd.DataFrame)
+    )
+    da_features = FeatureArray.from_feature_array(
+        wrap_features(np.ones((2, 5)), type=xr.DataArray)
+    )
+    ds_features = FeatureArray.from_feature_array(
+        wrap_features(np.ones((2, 5)), type=xr.Dataset)
+    )
+
+    called_meta = ufunc_meta.with_inputs(df_features, da_features, ds_features)
+
+    assert called_meta.postprocessor.__self__ is ds_features

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-import re
-
 import numpy as np
 import pytest
 
-from sklearn_raster.utils.decorators import (
-    map_over_arguments,
-    with_inputs_reshaped_to_ndim,
-)
+from sklearn_raster.utils.decorators import with_inputs_reshaped_to_ndim
 from sklearn_raster.utils.features import (
     can_cast_nodata_value,
     get_minimum_precise_numeric_dtype,
 )
+from sklearn_raster.utils.ufunc import _UfuncResult
 
 
 def test_minimum_precise_numeric_dtype():
@@ -25,29 +21,6 @@ def test_minimum_precise_numeric_dtype():
     # Floats should return their current precision
     assert get_minimum_precise_numeric_dtype(42.0) == np.float64
     assert get_minimum_precise_numeric_dtype(np.float32(np.nan)) == np.float32
-
-
-def test_map_over_arguments():
-    """Test that map_over_arguments decorator works as expected."""
-
-    @map_over_arguments("a", "b")
-    def func(a, b):
-        return a + b
-
-    assert func(1, 2) == 3
-    assert func(1, [2, 3]) == (3, 4)
-    assert func(a=[1, 2], b=[3, 4]) == (4, 6)
-
-    with pytest.raises(ValueError, match="must be the same length or scalar"):
-        func(a=[1, 2], b=[3, 4, 5])
-
-
-def test_map_over_arguments_validation():
-    """Test that map_over_arguments raises for unaccepted arguments."""
-    with pytest.raises(ValueError, match=re.escape("cannot be mapped over: ['a']")):
-
-        @map_over_arguments("a")
-        def _(): ...
 
 
 @pytest.mark.parametrize(
@@ -129,3 +102,33 @@ def test_can_cast_nodata_value(value: float | int, to_dtype: np.dtype, can_cast:
     Test that can_cast_nodata_value works as expected.
     """
     assert can_cast_nodata_value(value, to_dtype) == can_cast
+
+
+@pytest.mark.parametrize(("result", "unwrapped"), [(0, 0), ((0,), 0), ((0, 1), (0, 1))])
+def test_ufuncresult_unwraps(result, unwrapped):
+    assert _UfuncResult(result).unwrap() == unwrapped
+
+
+@pytest.mark.parametrize(("result", "length"), [(0, 1), ((0,), 1), ((0, 1), 2)])
+def test_ufuncresult_length(result, length):
+    assert len(_UfuncResult(result)) == length
+
+
+def test_ufuncresult_map():
+    result = _UfuncResult((1, 2, 3))
+    assert result.map(lambda x: x**2).unwrap() == (1, 4, 9)
+
+
+def test_ufuncresult_zipmap_single_value():
+    result = _UfuncResult(0)
+    assert result.zip_map(lambda x, y: x + y, (5,)).unwrap() == 5
+
+
+def test_ufuncresult_zipmap_tuple():
+    result = _UfuncResult((0, 0))
+    assert result.zip_map(lambda x, y: x + y, (5, 5)).unwrap() == (5, 5)
+
+
+def test_ufuncresult_map_passes_kwargs():
+    result = _UfuncResult(2)
+    assert result.zip_map(lambda x, pow: x**pow, pow=8).unwrap() == 256


### PR DESCRIPTION
Closes #107 by transposing ufunc parameters so that they're grouped by output, and adding a default `nodata` specification per-output to the ufunc which can be overridden at call time. For example, where we would have previously defined a ufunc as:

```python
ufunc = FeaturewiseUfunc(
    calculate_ogsi,
    output_dims=[["band"], ["band"], ["band"]],
    output_dtypes=[np.float32, np.uint8, np.uint8],
    output_sizes={"band": 1},
    output_coords=[{"band": ["OGSI"]}, {"band": ["LTQ"]}, {"band": ["OGSI_CLS"]}],
)
```

it would now be defined as (using some inference that's described in more detail below):

```python
ufunc = FeaturewiseUfunc(
    calculate_ogsi,
    outputs=[
        OutMeta.from_1d(name="band", coords=["OGSI"], dtype=np.float32),
        OutMeta.from_1d(name="band", coords=["LTQ"], dtype=np.uint8),
        # nodata defined explicitly for illustration
        OutMeta.from_1d(name="band", coords=["OGSI_CLS"], dtype=np.uint8, nodata=255),
    ]
)
```

This was implemented with a new `ufunc._meta` module that consists of four dataclasses used to store, validate, and convert metadata from the transposed format to the format expected by Xarray. 

There are two `_meta` classes used when defining a ufunc:
- `Dimension` describes one dimension of an output.
- `OutMeta` describes one output, including its dimensions, dtype, and default NoData value. The `OutMeta.from_1d` constructor allows you to define an output with a single dimension without manually building a `Dimension`, so often this is the only class you'll need to define a ufunc.

Two more `meta` classes are used internally when building and calling a ufunc:
- `_UfuncMeta` describes the ufunc's initial parameters (output dimensions, sizes, default NoData values, etc.) and is typically constructed using `_UfuncMeta.from_outputs` with a list of `OutMeta`.
- `_CalledUfuncMeta` is an extension of `_UfuncMeta` where all of the call-specific parameters (input dimensions, overriden NoData values, etc.) are populated, and is typically constructed from `_UfuncMeta.with_inputs`.

@grovduck, this is another PR that snowballed into a bigger set of changes that it probably should have been. I think we were pretty settled on the main changes above based on our previous discussions, but there were some other incidental changes and refactors (described in detail below) that came up that I think are worth discussing a little further, so I'll open this as a draft while we decide the best approach there.

EDIT: Sorry, I requested a review out of habit! Probably not worth diving too deeply into the code yet.

## Naming

As always, any input on naming would be appreciated! I wanted to keep the classes used for defining a ufunc relatively short to avoid ufunc definitions getting too verbose, but I feel like maybe `Dimension` and `OutMeta` are a little inconsistent and might be better as `DimMeta` and `OutMeta` or `Dimension` and `Output`? Or something else entirely. Also, do you think `OutMeta.from_1d` is convenient enough to be worth including, or does it just confuse things to have two ways to define metadata?

## Dimension size inference and validation

Dimensions now attempt to infer their size from their coordinates and raise an error if they're mismatched. This removes the need to specify a size if you also plan to specify coordinates.

## NoData inference

Now that the default output `nodata` value is defined alongside `dtype` for each output, it seemed like a natural extension to add NoData inference. The currrent system assigns NoData as:

- Floating point dtypes: `np.nan` in the defined precision
- Signed integer dtypes: the minimum value (e.g. -32768 for `int16`)
- Unsigned integer dtypes: the maximum value (e.g. 255 for `uint8`)

To avoid the complexity of accepting null NoData values for downstream processing, the current solution is to require either an explicit `nodata` or a numeric `dtype` when defining a ufunc. This is more strict than the previous behavior where we always defaulted to `float64(np.nan)` and only raised an error if that was incompatible with the dtype *and* the input data contained NoData that needed to be filled, but in some ways this is a bit of an apples-oranges comparison since we're being strict when the ufunc is defined but *less* strict when it's called, since we can guarantee the ufunc has defined a compatible NoData value.

@grovduck, I'm very curious what you think about the choices I made here. Specifically, should we try to infer NoData in the ufunc definition, do the inference rules I defined make sense or are they too arbitrary, and does it make sense to be strict in the ufunc definition vs. setting an arbitrary default like `np.nan`?

## Replace `map_over_arguments` with a "monad"

This is a refactor that wasn't directly related to the other changes, but simplified some of them and (I think) made the ufunc implementation more readable.

For context, our ufunc implementation is compatible with functions that return either single arrays or tuples of arrays, and at various points we need to apply processing to the return values and retrieve the result in the original format (single or tuple) to satisfy Xarray. This was originally solved with the `map_over_arguments` decorator that takes a function designed for a single arrays and automatically maps it over a tuple of arrays *and* any tuple arguments, but I've always found that pretty hard to reason about, easy to break with single-element tuples, and a bit convoluted by modifying the function to accept the data rather than vice versa. If you look at the commit history you'll see I took two stabs at replacing this, but what I ended up with was a monad-like data structure called a `UfuncResult` which wraps a single value or tuple of values and provides a consistent interface `map` for applying functions to either. When you need the original data format, you can use `unwrap` to retrieve it.

We often need to map over results that are zipped with corresponding tuples of metadata (coordinates or NoData values), so my current implemention of `map` also accepts optional positional arguments to be zipped prior to mapping. If it was more readable, we could consider splitting that out into a separate method like `zip_map` (this is how it's typically handled in functional languages, like `map2` in OCaml or `zipWith` in Haskell).

@grovduck, let me know what you think about this change. I think `UfuncResult` aligns better with my brain than `map_over_arguments` did, but that may just be me. We could explore other options if so. Also, would the implicit zipping over iterable arguments within `map` be more intuitive in a separate method, or do you think it's better to consolidate as it's currently implemented?
