### PR TITLE
Encode NaN like any other _FillValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - The output dimension from `predict_proba` was changed from `class` to `label` to avoid downstream syntax errors.
+- `NaN` is now encoded as a `_FillValue` like any other NoData value
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - The output dimension from `predict_proba` was changed from `class` to `label` to avoid downstream syntax errors.
-- `NaN` is now encoded as a `_FillValue` like any other NoData value
+- `NaN` is now encoded as a `_FillValue` like any other NoData value.
 
 ### Removed
 

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -300,7 +300,7 @@ class DataArrayFeatures(FeatureArray):
         attrs : dict[str, Any]
             Existing attributes to preserve or modify.
         fill_value : float | int, optional
-            The fill value to set for the _FillValue attribute. Ignored if None or NaN.
+            The fill value to set for the _FillValue attribute. Ignored if None.
         append_to_history : str, optional
             A string to append to the history attribute, typically the function name
             that was applied. If None, no history is appended.
@@ -321,7 +321,7 @@ class DataArrayFeatures(FeatureArray):
         elif prev_history:
             set_attrs["history"] = prev_history
 
-        if fill_value is not None and not np.isnan(fill_value):
+        if fill_value is not None:
             set_attrs["_FillValue"] = fill_value
 
         if new_attrs is not None:

--- a/tests/test_ufunc.py
+++ b/tests/test_ufunc.py
@@ -647,8 +647,7 @@ def test_ufunc_sets_dataarray_fillvalue(nodata_output: int | float):
     )
 
     if np.isnan(nodata_output):
-        # NaN should not be stored as a _FillValue
-        assert "_FillValue" not in result.attrs
+        assert np.isnan(result.attrs.get("_FillValue"))
     else:
         assert result.attrs.get("_FillValue") == nodata_output
 
@@ -674,9 +673,8 @@ def test_ufunc_sets_dataset_fillvalue(nodata_output: int | float):
     )
 
     for var in result.data_vars:
-        # NaN should not be stored as a _FillValue
         if np.isnan(nodata_output):
-            assert "_FillValue" not in result[var].attrs
+            assert np.isnan(result[var].attrs.get("_FillValue"))
         else:
             assert result[var].attrs.get("_FillValue") == nodata_output
 

--- a/tests/test_ufunc.py
+++ b/tests/test_ufunc.py
@@ -629,17 +629,20 @@ def test_ufunc_fills_nans(
     unwrap_features(result)
 
 
-@pytest.mark.parametrize("nodata_output", [np.nan, 0, -32768])
-def test_ufunc_sets_dataarray_fillvalue(nodata_output: int | float):
+@pytest.mark.parametrize(
+    ("dtype", "nodata_output"),
+    [(np.float64, np.nan), (np.uint8, 0), (np.int16, -32768)],
+)
+def test_ufunc_sets_dataarray_fillvalue(dtype, nodata_output: int | float):
     """Test that the output NoData value is stored as the _FillValue for a DataArray."""
-    a = np.array([[[1, 2, 3]]])
+    a = np.array([[[1, 2, 3]]], dtype=dtype)
     features = FeatureArray.from_feature_array(
         wrap_features(a, type=xr.DataArray), nodata_input=0
     )
 
     ufunc = FeaturewiseUfunc(
         lambda x: x,
-        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=dtype)],
     )
     result = ufunc(
         features,
@@ -652,20 +655,23 @@ def test_ufunc_sets_dataarray_fillvalue(nodata_output: int | float):
         assert result.attrs.get("_FillValue") == nodata_output
 
 
-@pytest.mark.parametrize("nodata_output", [np.nan, 0, -32768])
-def test_ufunc_sets_dataset_fillvalue(nodata_output: int | float):
+@pytest.mark.parametrize(
+    ("dtype", "nodata_output"),
+    [(np.float64, np.nan), (np.uint8, 0), (np.int16, -32768)],
+)
+def test_ufunc_sets_dataset_fillvalue(dtype, nodata_output: int | float):
     """
     Test that the output NoData value is stored as the _FillValue for each variable in a
     Dataset.
     """
-    a = np.array([[[1, 2, 3]]])
+    a = np.array([[[1, 2, 3]]], dtype=dtype)
     features = FeatureArray.from_feature_array(
         wrap_features(a, type=xr.Dataset), nodata_input=0
     )
 
     ufunc = FeaturewiseUfunc(
         lambda x: x,
-        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
+        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=dtype)],
     )
     result = ufunc(
         features,


### PR DESCRIPTION
Close #111 by encoding NaN like any other _FillValue. I confirmed that when the result is written to GeoTIFF using rioxarray, gdalinfo and QGIS will now recognize the NoData value as `nan` instead of missing. 