### PR TITLE
Validate and cast for NoData regardless of masked values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - The output dimension from `predict_proba` was changed from `class` to `label` to avoid downstream syntax errors.
 - `NaN` is now encoded as a `_FillValue` like any other NoData value.
+- Output NoData values are now validated against array data types regardless of whether input arrays contain masked values, preventing setting incompatible `_FillValue` metadata that would break downstream serialization.
 
 ### Removed
 

--- a/src/sklearn_raster/ufunc/_base.py
+++ b/src/sklearn_raster/ufunc/_base.py
@@ -322,17 +322,20 @@ class FeaturewiseUfunc:
 
         def mask_nodata(result: NDArray, nodata_output: float | int) -> NDArray:
             """Replace NoData values in the input array with `output_nodata`."""
-            result = self._maybe_cast_for_nodata(
-                result,
-                nodata_output,
-                allow_cast=allow_cast,
-                check_output_for_nodata=check_output_for_nodata,
-            )
-
             result[nodata_mask] = nodata_output
             return result
 
-        result = self._validate_result(self.func(*arrays, **kwargs))
+        result = (
+            self._validate_result(self.func(*arrays, **kwargs))
+            # Validate and check for NoData even if there's no mask since we may store
+            # metadata like a _FillValue
+            .zip_map(
+                self._maybe_cast_for_nodata,
+                nodata_outputs,
+                allow_cast=allow_cast,
+                check_output_for_nodata=check_output_for_nodata,
+            )
+        )
 
         if nodata_mask is not None:
             return result.zip_map(mask_nodata, nodata_outputs)
@@ -381,13 +384,6 @@ class FeaturewiseUfunc:
             result: NDArray, nodata_output: float | int
         ) -> NDArray:
             """Insert the array result for valid samples into the full-shaped array."""
-            result = self._maybe_cast_for_nodata(
-                result,
-                nodata_output,
-                allow_cast=allow_cast,
-                check_output_for_nodata=check_output_for_nodata,
-            )
-
             # Ensure that the result has a feature dimension in case it was squeezed by
             # the ufunc. `atleast_2d` adds the new axis at the index 0, so transpose
             # twice to move it to the end.
@@ -411,9 +407,18 @@ class FeaturewiseUfunc:
             return full_result
 
         # Apply the func only to valid samples
-        return self._validate_result(
-            self.func(*[array[~nodata_mask] for array in arrays], **kwargs)
-        ).zip_map(populate_missing_samples, nodata_outputs)
+        result = self.func(*[array[~nodata_mask] for array in arrays], **kwargs)
+
+        return (
+            self._validate_result(result)
+            .zip_map(
+                self._maybe_cast_for_nodata,
+                nodata_outputs,
+                allow_cast=allow_cast,
+                check_output_for_nodata=check_output_for_nodata,
+            )
+            .zip_map(populate_missing_samples, nodata_outputs)
+        )
 
     def _maybe_cast_for_nodata(
         self,

--- a/src/sklearn_raster/ufunc/_base.py
+++ b/src/sklearn_raster/ufunc/_base.py
@@ -13,7 +13,7 @@ from ..utils.decorators import (
     limit_inner_threads,
     with_inputs_reshaped_to_ndim,
 )
-from ..utils.features import get_minimum_precise_numeric_dtype
+from ..utils.features import can_cast_nodata_value, get_minimum_precise_numeric_dtype
 from ..utils.ufunc import _UfuncResult
 from ._meta import _UfuncMeta
 
@@ -435,27 +435,19 @@ class FeaturewiseUfunc:
         """
         nodata_output_type = get_minimum_precise_numeric_dtype(nodata_output)
 
-        if not np.can_cast(nodata_output_type, output.dtype):
+        # Use permissive casting rules to allow storing equivalent NoData values, e.g.
+        # whole-number floats in integer arrays or larger floats in smaller float arrays
+        # where precision isn't lost.
+        if not can_cast_nodata_value(nodata_output, output.dtype):
             if allow_cast:
                 output = output.astype(nodata_output_type)
             else:
-                msg = (
+                raise ValueError(
                     f"The selected `nodata_output` value {nodata_output} "
                     f"({nodata_output_type}) does not fit in the array dtype "
-                    f"({output.dtype}). "
+                    f"({output.dtype}). Consider choosing a different `nodata_output` "
+                    "value or set `allow_cast=True` to automatically cast the output."
                 )
-                if nodata_output_type.kind == output.dtype.kind == "f":
-                    msg += (
-                        "Consider casting `nodata_output` to a lower precision float "
-                        "or set `allow_cast=True` to automatically cast the output."
-                    )
-                else:
-                    msg += (
-                        "Consider choosing a different `nodata_output` value or set "
-                        "`allow_cast=True` to automatically cast the output."
-                    )
-
-                raise ValueError(msg)
 
         if (
             check_output_for_nodata

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -52,7 +52,7 @@ def test_predict_unsupervised(model_data: ModelData, estimator):
 
     estimator = FeatureArrayEstimator(estimator()).fit(X)
 
-    y_pred = unwrap_features(estimator.predict(X_image))
+    y_pred = unwrap_features(estimator.predict(X_image, nodata_output=-32768))
 
     assert y_pred.ndim == 3
     expected_shape = (1, model_data.n_rows, model_data.n_cols)

--- a/tests/test_ufunc.py
+++ b/tests/test_ufunc.py
@@ -216,17 +216,18 @@ def test_ufunc_does_not_mutate_input(
 
 @parametrize_feature_array_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
+@pytest.mark.parametrize("input_val", [np.nan, 0])
 @pytest.mark.parametrize(
     "val_dtype", [(-1, np.dtype(np.uint8)), (np.nan, np.dtype(np.int16))]
 )
 def test_ufunc_raises_with_unsupported_nodata_output_dtype(
+    input_val: int | float,
     val_dtype: tuple[int | float, np.dtype],
     feature_array_type: type[FeatureArrayType],
     skip_nodata: bool,
 ):
     """Test that an error is raised when nodata_output is the wrong dtype."""
-    # Make sure there's a value to mask in the input array
-    a = np.array([[[np.nan]]])
+    a = np.array([[[input_val]]])
     array = wrap_features(a, type=feature_array_type)
     features = FeatureArray.from_feature_array(array, nodata_input=0)
 
@@ -254,12 +255,14 @@ def test_ufunc_raises_with_unsupported_nodata_output_dtype(
 @pytest.mark.parametrize(
     "dtypes", [(np.float64, np.dtype(np.float32)), (np.float32, np.dtype(np.float16))]
 )
+@pytest.mark.parametrize("input_val", [np.nan, 0])
 def test_ufunc_raises_with_unsupported_nodata_output_float_precision(
-    feature_array_type: type[FeatureArrayType], dtypes: tuple[np.dtype, np.dtype]
+    feature_array_type: type[FeatureArrayType],
+    dtypes: tuple[np.dtype, np.dtype],
+    input_val: int | float,
 ):
     """Test that an error is raised when nodata_output is the wrong float precision."""
-    # Make sure there's a value to mask in the input array
-    a = np.array([[[np.nan]]])
+    a = np.array([[[input_val]]])
     array = wrap_features(a, type=feature_array_type)
     features = FeatureArray.from_feature_array(array, nodata_input=0)
 
@@ -281,17 +284,18 @@ def test_ufunc_raises_with_unsupported_nodata_output_float_precision(
 
 @parametrize_feature_array_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
+@pytest.mark.parametrize("input_val", [np.nan, 0])
 @pytest.mark.parametrize(
     "val_dtypes", [(-1, np.uint8, np.int8), (np.nan, np.int16, np.float64)]
 )
 def test_ufunc_allows_casting_of_unsupported_nodata_output(
     val_dtypes: tuple[int | float, np.dtype, np.dtype],
+    input_val: int | float,
     feature_array_type: type[FeatureArrayType],
     skip_nodata: bool,
 ):
-    """Test that an unsupported nodata_output value correctly casts if allowed."""
-    # Make sure there's a value to mask in the input array
-    a = np.array([[[np.nan]]])
+    """Test that an unsupported nodata_output value correctly casts when allowed."""
+    a = np.array([[[input_val]]])
     array = wrap_features(a, type=feature_array_type)
     features = FeatureArray.from_feature_array(array, nodata_input=0)
 
@@ -311,34 +315,6 @@ def test_ufunc_allows_casting_of_unsupported_nodata_output(
     )
 
     assert result.dtype == expected_dtype
-
-
-@parametrize_feature_array_types()
-@pytest.mark.parametrize("input_dtype", [np.uint8, np.float32])
-def test_ufunc_skips_nodata_output_validation_if_unmasked(
-    feature_array_type: type[FeatureArrayType],
-    input_dtype: np.dtype,
-):
-    """If the input doesn't contain NoData, we shouldn't test nodata_output's dtype."""
-    # Make a feature array without any NoData
-    a = np.ones((4, 4), dtype=input_dtype)
-    array = wrap_features(a, type=feature_array_type)
-    features = FeatureArray.from_feature_array(array, nodata_input=0)
-
-    ufunc = FeaturewiseUfunc(
-        lambda x: x,
-        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
-    )
-    # Unwrap to force computation for lazy arrays
-    unwrap_features(
-        ufunc(
-            features,
-            # Set a value that doesn't fit in the feature array type
-            nodata_output=np.float64(np.nan),
-            skip_nodata=True,
-            allow_cast=False,
-        )
-    )
 
 
 @pytest.mark.parametrize("nodata_output", [np.nan, 42.0])

--- a/tests/test_ufunc.py
+++ b/tests/test_ufunc.py
@@ -252,37 +252,6 @@ def test_ufunc_raises_with_unsupported_nodata_output_dtype(
 
 
 @parametrize_feature_array_types()
-@pytest.mark.parametrize(
-    "dtypes", [(np.float64, np.dtype(np.float32)), (np.float32, np.dtype(np.float16))]
-)
-@pytest.mark.parametrize("input_val", [np.nan, 0])
-def test_ufunc_raises_with_unsupported_nodata_output_float_precision(
-    feature_array_type: type[FeatureArrayType],
-    dtypes: tuple[np.dtype, np.dtype],
-    input_val: int | float,
-):
-    """Test that an error is raised when nodata_output is the wrong float precision."""
-    a = np.array([[[input_val]]])
-    array = wrap_features(a, type=feature_array_type)
-    features = FeatureArray.from_feature_array(array, nodata_input=0)
-
-    chosen_dtype, return_dtype = dtypes
-    expected_msg = "Consider casting `nodata_output` to a lower precision"
-    ufunc = FeaturewiseUfunc(
-        lambda x: np.ones_like(x).astype(return_dtype),
-        outputs=[Output.from_1d("variable", size=a.shape[0], dtype=a.dtype)],
-    )
-    with pytest.raises(ValueError, match=expected_msg):
-        # Unwrap to force computation for lazy arrays
-        unwrap_features(
-            ufunc(
-                features,
-                nodata_output=chosen_dtype(np.nan),
-            )
-        )
-
-
-@parametrize_feature_array_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
 @pytest.mark.parametrize("input_val", [np.nan, 0])
 @pytest.mark.parametrize(

--- a/tests/test_ufunc.py
+++ b/tests/test_ufunc.py
@@ -216,7 +216,7 @@ def test_ufunc_does_not_mutate_input(
 
 @parametrize_feature_array_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
-@pytest.mark.parametrize("input_val", [np.nan, 0])
+@pytest.mark.parametrize("input_val", [np.nan, 99])
 @pytest.mark.parametrize(
     "val_dtype", [(-1, np.dtype(np.uint8)), (np.nan, np.dtype(np.int16))]
 )
@@ -253,7 +253,7 @@ def test_ufunc_raises_with_unsupported_nodata_output_dtype(
 
 @parametrize_feature_array_types()
 @pytest.mark.parametrize("skip_nodata", [True, False])
-@pytest.mark.parametrize("input_val", [np.nan, 0])
+@pytest.mark.parametrize("input_val", [np.nan, 99])
 @pytest.mark.parametrize(
     "val_dtypes", [(-1, np.uint8, np.int8), (np.nan, np.int16, np.float64)]
 )


### PR DESCRIPTION
We previously only validated the selected output NoData value(s) when the input array(s) contained masked values. However, this allowed setting incompatible or conflicting metadata in the `_FillValue`, which could cause downstream processing (e.g. `rio.to_raster`) to fail, or for valid pixels to be interpreted as NoData if they conflict with `_FillValue`. It also made validation inconsistent across calls depending on the input data, which could potentially be surprising.

For example, the code below would succeed because the input data has no masked values, but write an incompatible `_FillValue` in the result:

```python
from sklearn_raster.ufunc import FeaturewiseUfunc, Output
from sklearn_raster.features import FeatureArray
import xarray as xr
import numpy as np

# Create a feature array without any masked values
da = FeatureArray.from_feature_array(xr.DataArray(
    np.array([[[1, 2, 0], [4, 5, 6]]], dtype=np.uint8),
    dims=["band", "x", "y"],
))

# Call a ufunc that sets an incompatible NoData value
result = FeaturewiseUfunc(
    lambda x: x + 1,
    outputs=[Output.from_1d("result", coords=["b1"], nodata=-32768)],
)(da)
```

When you attempt to export with rioxarray, you'll get an error:

```python
result.rio.to_raster("result.tif")
# OverflowError: Unable to convert nodata value (-32768) to new dtype (uint8).
```

To avoid those errors and inconsistent behavior, NoData values are now always validated against the ufunc result dtypes, regardless of whether there are masked values. The code above would now fail immediately with:

```python
result = FeaturewiseUfunc(
    lambda x: x + 1,
    outputs=[Output.from_1d("result", coords=["b1"], nodata=-32768)],
)(da)
# ValueError: The selected `nodata_output` value -32768 (int16) does not fit in the array dtype (uint8). Consider choosing a different `nodata_output` value or set `allow_cast=True` to automatically cast the output.
```