### PR TITLE
Add `flake8-type-checking` rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ fix = true
 show-fixes = true
 
 [tool.ruff.lint]
-select = ["E", "I", "F", "B", "FA", "UP", "PT", "Q", "RET", "SIM", "PERF"]
+select = ["E", "I", "F", "B", "FA", "UP", "PT", "Q", "RET", "SIM", "PERF", "TC"]
 isort.known-first-party = ["sklearn_raster"]
 
 [tool.hatch.metadata]

--- a/src/sklearn_raster/datasets/_base.py
+++ b/src/sklearn_raster/datasets/_base.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
-import pandas as pd
-from numpy.typing import NDArray
 
 from sklearn_raster import __version__
 from sklearn_raster.datasets._registry import registry
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from numpy.typing import NDArray
 
 try:
     import pooch

--- a/src/sklearn_raster/datasets/synthetic.py
+++ b/src/sklearn_raster/datasets/synthetic.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
-import pandas as pd
-from numpy.typing import NDArray
 from sklearn.decomposition import PCA
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
@@ -13,7 +11,9 @@ from sklearn_raster import FeatureArrayEstimator
 from sklearn_raster.utils.estimator import generate_sequential_names
 
 if TYPE_CHECKING:
+    import pandas as pd
     import xarray as xr
+    from numpy.typing import NDArray
 
 
 @overload

--- a/src/sklearn_raster/estimator.py
+++ b/src/sklearn_raster/estimator.py
@@ -486,7 +486,9 @@ class FeatureArrayEstimator(Generic[EstimatorType], BaseEstimator):
 
         features = FeatureArray.from_feature_array(X, nodata_input=nodata_input)
         self._check_feature_names(features.feature_names)
-        k = n_neighbors or cast(int, getattr(self.wrapped_estimator, "n_neighbors", 5))
+        k = n_neighbors or cast(
+            "int", getattr(self.wrapped_estimator, "n_neighbors", 5)
+        )
 
         neighbor_dim = Dimension(
             name="neighbor", size=k, coords=generate_sequential_names(k, "neighbor")

--- a/src/sklearn_raster/features.py
+++ b/src/sklearn_raster/features.py
@@ -4,13 +4,12 @@ from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Callable, Sequence, Sized
 from datetime import UTC, datetime
-from typing import Any, Generic
+from typing import TYPE_CHECKING, Any, Generic
 
 import numpy as np
 import numpy.ma as ma
 import pandas as pd
 import xarray as xr
-from numpy.typing import NDArray
 
 from .types import (
     FeatureArrayType,
@@ -19,6 +18,9 @@ from .types import (
     NoDataType,
 )
 from .utils.features import can_cast_nodata_value
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 class FeatureArray(Generic[FeatureArrayType], ABC):

--- a/src/sklearn_raster/ufunc/_base.py
+++ b/src/sklearn_raster/ufunc/_base.py
@@ -6,9 +6,7 @@ from warnings import warn
 import numpy as np
 import numpy.ma as ma
 import xarray as xr
-from numpy.typing import NDArray
 
-from ..types import ArrayUfunc, FeatureArrayType, MaybeTuple
 from ..utils.decorators import (
     limit_inner_threads,
     with_inputs_reshaped_to_ndim,
@@ -18,7 +16,10 @@ from ..utils.ufunc import _UfuncResult
 from ._meta import _UfuncMeta
 
 if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
     from ..features import FeatureArray
+    from ..types import ArrayUfunc, FeatureArrayType, MaybeTuple
     from ._meta import Output
 
 
@@ -359,7 +360,7 @@ class FeaturewiseUfunc:
 
         # The NoData mask is guaranteed to exist since this method is only called when
         # there are masked samples, so we can safely cast it for type checking.
-        nodata_mask = cast(NDArray, nodata_mask)
+        nodata_mask = cast("NDArray", nodata_mask)
         num_unmasked = (~nodata_mask).sum()
 
         if inserted_dummy_values := num_unmasked < ensure_min_samples:

--- a/src/sklearn_raster/ufunc/_meta.py
+++ b/src/sklearn_raster/ufunc/_meta.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -12,7 +12,11 @@ from ..features import (
     FeatureArray,
     NDArrayFeatures,
 )
-from ..types import MaybeTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from ..types import MaybeTuple
 
 
 @dataclass

--- a/src/sklearn_raster/utils/decorators.py
+++ b/src/sklearn_raster/utils/decorators.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING, Concatenate
 
 import threadpoolctl
-from numpy.typing import NDArray
 from sklearn.utils.validation import check_is_fitted
 
-from ..types import RT, MaybeTuple, P
 from .ufunc import _UfuncResult
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
     from ..estimator import FeatureArrayEstimator
+    from ..types import RT, MaybeTuple, P
 
 
 # Global threadpool controller instance for limiting threads in decorated ufuncs.

--- a/src/sklearn_raster/utils/ufunc.py
+++ b/src/sklearn_raster/utils/ufunc.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Collection
-from typing import Generic
+from typing import TYPE_CHECKING, Generic
 
 from ..types import RT, MaybeTuple, T
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
 
 
 class _UfuncResult(Generic[T]):

--- a/tests/feature_utils.py
+++ b/tests/feature_utils.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Literal
+from typing import TYPE_CHECKING, Any, Generic, Literal
 
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from numpy.typing import NDArray
 
 from sklearn_raster.types import FeatureArrayType
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 # Dimension names to use when building Xarray features, in order of increasing
 # dimensionality, excluding the first "variable" dimension.

--- a/tests/test_ufunc.py
+++ b/tests/test_ufunc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -10,7 +11,6 @@ import xarray as xr
 from numpy.testing import assert_array_equal
 
 from sklearn_raster.features import FeatureArray
-from sklearn_raster.types import FeatureArrayType
 from sklearn_raster.ufunc import FeaturewiseUfunc, Output
 from sklearn_raster.utils.features import get_minimum_precise_numeric_dtype
 
@@ -19,6 +19,9 @@ from .feature_utils import (
     unwrap_features,
     wrap_features,
 )
+
+if TYPE_CHECKING:
+    from sklearn_raster.types import FeatureArrayType
 
 
 @parametrize_feature_array_types()


### PR DESCRIPTION
Adds [flake8-type-checking](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) rules to pre-commit ruff checks to verify that typing-only imports are only included during type-checking to speed up imports.