### PR TITLE
Pin mkdocs<2.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs
+mkdocs<2.0.0
 mkdocs-material
 mkdocstrings[python]
 mkdocs-jupyter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ python = ["3.11", "3.12", "3.13", "3.14"]
 [tool.hatch.envs.docs]
 dependencies = [
     "sklearn-raster[tutorials]",
-    "mkdocs",
+    "mkdocs<2.0.0",
     "mkdocs-material",
     "mkdocstrings[python]",
     "mkdocs-jupyter",


### PR DESCRIPTION
This is a short-term fix for the docs build failures caused by the incompatible major version jump in mkdocs 2.0. I'll leave #119 open to track a longer-term fix, but this should get things running again.